### PR TITLE
Deduplicate tokenize_line and minor optimizations in taf/maf parsing

### DIFF
--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -280,23 +280,23 @@ void alignment_mask_reference_bases(Alignment *alignment, char mask_char) {
 /*
  * Returns a sequence of tags from the tokens, starting at starting_token
  */
-Tag *parse_tags(stList *tokens, int64_t starting_token, char *delimiter) {
+Tag *parse_tags(char **tokens, int n_tokens, int64_t starting_token, char *delimiter) {
     Tag *first_tag = NULL, *tag = NULL;
-    if(starting_token < stList_length(tokens)) { // parse first tag pair
-        tag = tag_parse(stList_get(tokens, starting_token), delimiter, NULL);
+    if(starting_token < n_tokens) { // parse first tag pair
+        tag = tag_parse(tokens[starting_token], delimiter, NULL);
         first_tag = tag;
     }
-    for(int64_t i=starting_token+1; i<stList_length(tokens); i++) {
-        tag = tag_parse(stList_get(tokens, i), delimiter, tag);
+    for(int64_t i=starting_token+1; i<n_tokens; i++) {
+        tag = tag_parse(tokens[i], delimiter, tag);
     }
     return first_tag;
 }
 
-Tag *parse_header(stList *tokens, char *header_prefix, char *delimiter) {
-    if(stList_length(tokens) == 0 || strcmp((char *)stList_get(tokens, 0), header_prefix) != 0) {
+Tag *parse_header(char **tokens, int n_tokens, char *header_prefix, char *delimiter) {
+    if(n_tokens == 0 || strcmp(tokens[0], header_prefix) != 0) {
         st_errAbort("Header line does not start with %s\n", header_prefix);
     }
-    return parse_tags(tokens, 1, delimiter);
+    return parse_tags(tokens, n_tokens, 1, delimiter);
 }
 
 void write_header(Tag *tag, LW *lw, char *header_prefix, char *delimiter, char *end) {

--- a/taffy/impl/line_iterator.c
+++ b/taffy/impl/line_iterator.c
@@ -84,16 +84,18 @@ int64_t LI_tell(LI *li) {
 LW *LW_construct(FILE *fh, bool use_compression) {
     LW *lw = st_calloc(1, sizeof(LW));
     lw->fh = fh;
-    if(use_compression) {
 #ifdef USE_HTSLIB
+    lw->buf_cap = 65536;
+    lw->buf = st_malloc(lw->buf_cap);
+    if(use_compression) {
         lw->bgzf = bgzf_dopen(fileno(fh), "w");
         assert(lw->bgzf);
         assert(bgzf_compression(lw->bgzf) == 2);
         if (bgzf_index_build_init(lw->bgzf) != 0) {
             assert(false);
         }
-#endif
     }
+#endif
     return lw;
 }
 
@@ -107,6 +109,7 @@ void LW_destruct(LW *lw, bool clean_up_file_handle) {
             assert(0); // Close failed
         }
     }
+    free(lw->buf);
 #endif
     if(clean_up_file_handle) {
         fclose(lw->fh);
@@ -119,20 +122,19 @@ int LW_write(LW *lw, const char *string, ...) {
     int i;
     va_list ap;
     if(lw->bgzf) { // Use bgzf compression
-        // Figure out how long the string is to build the buffer
-        va_start(ap, string);
-        int j = vsnprintf(NULL, 0, string, ap)+1;
-        assert(j >= 0);
-        va_end(ap);
-        // Now write the string into the buffer
-        va_start(ap, string);
-        char ret[j];
-        i = vsnprintf(ret, j, string, ap);
-        assert(ret[i] == '\0');
-        // Finally, write the buffer to the bgzf stream
-        i = bgzf_write(lw->bgzf, ret, i);
-        assert(i+1 == j);
-        va_end(ap);
+        int n;
+        while (1) {
+            va_start(ap, string);
+            n = vsnprintf(lw->buf, lw->buf_cap, string, ap);
+            va_end(ap);
+            if (n >= 0 && (size_t)n < lw->buf_cap) break;
+            // Buffer too small; grow and retry
+            lw->buf_cap = (n >= 0) ? (size_t)(n + 1) : lw->buf_cap * 2;
+            lw->buf = st_realloc(lw->buf, lw->buf_cap);
+        }
+        ssize_t written = bgzf_write(lw->bgzf, lw->buf, n);
+        assert(written == (ssize_t)n);
+        i = (int)written;
     }
     else { // No compression, just fprintf to the stream
         va_start(ap, string);
@@ -147,5 +149,18 @@ int LW_write(LW *lw, const char *string, ...) {
     va_end(ap);
     return i;
 #endif
+}
+
+int LW_write_bytes(LW *lw, const char *data, int len) {
+#ifdef USE_HTSLIB
+    if(lw->bgzf) {
+        ssize_t written = bgzf_write(lw->bgzf, data, (size_t)len);
+        assert(written == (ssize_t)len);
+        return (int)written;
+    }
+#endif
+    int written = (int)fwrite(data, 1, (size_t)len, lw->fh);
+    assert(written == len);
+    return written;
 }
 

--- a/taffy/impl/maf.c
+++ b/taffy/impl/maf.c
@@ -6,19 +6,19 @@
 #include "line_iterator.h"
 
 Alignment *maf_read_block(LI *li) {
+    char *tokens_buf[MAX_TOKENS];
     while(1) {
         char *line = LI_get_next_line(li);
         if(line == NULL) {
             return NULL;
         }
-        stList *tokens = stString_split(line);
-        free(line);
-        if(stList_length(tokens) == 0) {
-            stList_destruct(tokens);
+        int n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
+        if(n_tokens == 0) {
+            free(line);
             continue;
         }
-        if(strcmp(stList_get(tokens, 0), "a") == 0) { // If is an "a" line
-            stList_destruct(tokens);
+        if(strcmp(tokens_buf[0], "a") == 0) { // If is an "a" line
+            free(line);
             Alignment *alignment = st_calloc(1, sizeof(Alignment));
             Alignment_Row **p_row = &(alignment->row);
             while(1) {
@@ -26,30 +26,29 @@ Alignment *maf_read_block(LI *li) {
                 if(line == NULL) {
                     return alignment;
                 }
-                tokens = stString_split(line);
-                free(line);
-                if(stList_length(tokens) == 0) {
-                    stList_destruct(tokens);
+                n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
+                if(n_tokens == 0) {
+                    free(line);
                     return alignment;
                 }
-                if(strcmp(stList_get(tokens, 0), "s") != 0) {
-                    assert(strcmp(stList_get(tokens, 0), "i") == 0 || strcmp(stList_get(tokens, 0), "e") == 0); // Must be an "i" or "e" line, which we ignore
-                    stList_destruct(tokens);
+                if(strcmp(tokens_buf[0], "s") != 0) {
+                    assert(strcmp(tokens_buf[0], "i") == 0 || strcmp(tokens_buf[0], "e") == 0); // Must be an "i" or "e" line, which we ignore
+                    free(line);
                     continue;
                 }
-                assert(strcmp(stList_get(tokens, 0), "s") == 0); // Must be an "s" line
+                assert(strcmp(tokens_buf[0], "s") == 0); // Must be an "s" line
                 Alignment_Row *row = st_calloc(1, sizeof(Alignment_Row));
                 alignment->row_number++;
                 *p_row = row;
                 p_row = &(row->n_row);
-                row->sequence_name = stString_copy(stList_get(tokens, 1));
-                row->start = atol(stList_get(tokens, 2));
-                row->length = atol(stList_get(tokens, 3));
-                assert(strcmp(stList_get(tokens, 4), "+") == 0 || strcmp(stList_get(tokens, 4), "-") == 0);
-                row->strand = strcmp(stList_get(tokens, 4), "+") == 0;
-                row->sequence_length = atol(stList_get(tokens, 5));
-                row->bases = stString_copy(stList_get(tokens, 6));
-                stList_destruct(tokens);
+                row->sequence_name = stString_copy(tokens_buf[1]);
+                row->start = atol(tokens_buf[2]);
+                row->length = atol(tokens_buf[3]);
+                assert(strcmp(tokens_buf[4], "+") == 0 || strcmp(tokens_buf[4], "-") == 0);
+                row->strand = strcmp(tokens_buf[4], "+") == 0;
+                row->sequence_length = atol(tokens_buf[5]);
+                row->bases = stString_copy(tokens_buf[6]);
+                free(line);
                 if(alignment->row_number == 1) {
                     alignment->column_number = strlen(row->bases);
                     alignment->column_tags = st_calloc(alignment->column_number, sizeof(Tag *));
@@ -61,21 +60,20 @@ Alignment *maf_read_block(LI *li) {
             return alignment;
         }
         else {
-            assert(strcmp(stList_get(tokens, 0), "s") != 0); // Can not be an s line without a prior a line - we will ignore this line
-            stList_destruct(tokens);
+            assert(strcmp(tokens_buf[0], "s") != 0); // Can not be an s line without a prior a line - we will ignore this line
+            free(line);
         }
     }
 }
 
-Tag *parse_header(stList *tokens, char *header_prefix, char *delimiter);
+Tag *parse_header(char **tokens, int n_tokens, char *header_prefix, char *delimiter);
 
 Tag *maf_read_header(LI *li) {
     char *line = LI_get_next_line(li);
-    stList *tokens = stString_split(line);
+    char *tokens_buf[MAX_TOKENS];
+    int n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
+    Tag *tag = parse_header(tokens_buf, n_tokens, "##maf", "=");
     free(line);
-    Tag *tag = parse_header(tokens, "##maf", "=");
-    stList_destruct(tokens);
-
     return tag;
 }
 

--- a/taffy/impl/maf.c
+++ b/taffy/impl/maf.c
@@ -82,12 +82,16 @@ void maf_write_block2(Alignment *alignment, LW *lw, bool color_bases) {
     Alignment_Row *row = alignment->row;
     while(row != NULL) {
         char *bases = color_bases ? color_base_string(row->bases, alignment->column_number) : row->bases;
-        LW_write(lw, "s\t%s\t%" PRIi64 "\t%" PRIi64 "\t%s\t%" PRIi64 "\t%s\n", row->sequence_name, row->start, row->length,
-                row->strand ? "+" : "-", row->sequence_length, bases);
-        row = row->n_row;
+        int bases_len = color_bases ? (int)strlen(bases) : (int)alignment->column_number;
+        LW_write(lw, "s\t%s\t%" PRIi64 "\t%" PRIi64 "\t%c\t%" PRIi64 "\t",
+                 row->sequence_name, row->start, row->length,
+                 row->strand ? '+' : '-', row->sequence_length);
+        LW_write_bytes(lw, bases, bases_len);
+        LW_write(lw, "\n");
         if(color_bases) {
             free(bases);
         }
+        row = row->n_row;
     }
     LW_write(lw, "\n"); // Add a blank line at the end of the block
 }

--- a/taffy/impl/taf.c
+++ b/taffy/impl/taf.c
@@ -125,12 +125,12 @@ static char *get_bases(int64_t column_length, char **tokens, int n_tokens, bool 
         int64_t i=0, j=0;
         while(j < column_length) {
             assert(i < n_tokens);
-            char *base_token = tokens[i++];
-            assert(strlen(base_token) == 1); // The base must be a single character
+            assert(strlen(tokens[i]) == 1); // The base must be a single character
+            char base_token = tokens[i++][0];
             int64_t k = atol(tokens[i++]);
             assert(k > 0); // Each count must be greater than zero
             while(k-- > 0) {
-                column[j++] = base_token[0];
+                column[j++] = base_token;
             }
             assert(j <= column_length);
         }

--- a/taffy/impl/taf.c
+++ b/taffy/impl/taf.c
@@ -2,11 +2,27 @@
 #include "sonLib.h"
 
 /*
- * Returns non-zero if the tokens list contains the coordinate marker ':'
+ * Non-destructive scan: returns true if the line contains ";" as a
+ * whitespace-delimited token (i.e. this is a coordinate line).
  */
-bool has_coordinates(stList *tokens, int64_t *j) {
-    for(*j=0; *j<stList_length(tokens); (*j)++) {
-        if(strcmp(stList_get(tokens, *j), ";") == 0) {
+static bool line_has_coordinates(const char *line) {
+    const char *p = line;
+    while (*p != '\0') {
+        while (*p != '\0' && isspace((unsigned char)*p)) p++;
+        if (*p == '\0') break;
+        const char *start = p;
+        while (*p != '\0' && !isspace((unsigned char)*p)) p++;
+        if (p - start == 1 && *start == ';') return true;
+    }
+    return false;
+}
+
+/*
+ * Returns non-zero if the tokens array contains the coordinate marker ';'
+ */
+bool has_coordinates(char **tokens, int n_tokens, int64_t *j) {
+    for(*j=0; *j<n_tokens; (*j)++) {
+        if(strcmp(tokens[*j], ";") == 0) {
             return 1;
         }
     }
@@ -16,13 +32,13 @@ bool has_coordinates(stList *tokens, int64_t *j) {
 /*
  * Parse the sequence_name, start, strand and sequence_length fields for a row
  */
-char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand,
-                        int64_t *sequence_length) {  
-    char *sequence_name = stString_copy(stList_get(tokens, (*j)++));
-    *start = atol(stList_get(tokens, (*j)++));
-    assert(strcmp(stList_get(tokens, (*j)), "+") == 0 || strcmp(stList_get(tokens, (*j)), "-") == 0);
-    *strand = strcmp(stList_get(tokens, (*j)++), "+") == 0;
-    *sequence_length = atol(stList_get(tokens, (*j)++));
+char *parse_coordinates(int64_t *j, char **tokens, int n_tokens, int64_t *start, bool *strand,
+                        int64_t *sequence_length) {
+    char *sequence_name = stString_copy(tokens[(*j)++]);
+    *start = atol(tokens[(*j)++]);
+    assert(strcmp(tokens[*j], "+") == 0 || strcmp(tokens[*j], "-") == 0);
+    *strand = strcmp(tokens[(*j)++], "+") == 0;
+    *sequence_length = atol(tokens[(*j)++]);
     return sequence_name;
 }
 
@@ -30,7 +46,7 @@ char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand
  * Make the block being parsed by copying the previous block and then editing it with the
  * list of coordinate changes.
  */
-static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, stList *tokens) {
+static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, char **tokens, int n_tokens) {
     // Make a new block
     Alignment *alignment = st_calloc(1, sizeof(Alignment));
 
@@ -57,11 +73,11 @@ static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, stLi
 
     // Now parse the tokens to edit the rows
     int64_t j;
-    has_coordinates(tokens, &j); j++; // Get 1+ the coordinate of the ';' token
-    while(j < stList_length(tokens) && strcmp(stList_get(tokens, j), "@") != 0) { // Iterate through the tokens
-        char *op_type = stList_get(tokens, j++); // This is the operation
+    has_coordinates(tokens, n_tokens, &j); j++; // Get 1+ the coordinate of the ';' token
+    while(j < n_tokens && strcmp(tokens[j], "@") != 0) { // Iterate through the tokens
+        char *op_type = tokens[j++]; // This is the operation
         assert(strlen(op_type) == 1); // Must be a single character in length
-        int64_t row_index = atol(stList_get(tokens, j++)); // Get the index of the affected row
+        int64_t row_index = atol(tokens[j++]); // Get the index of the affected row
         int64_t i=0;
         Alignment_Row **row = &(alignment->row); // Get the pointer to the pointer to the row being modded
         while(i++ < row_index) {
@@ -75,10 +91,10 @@ static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, stLi
             new_row->n_row = *row;
             *row = new_row;
             // Fill it out
-            new_row->sequence_name = parse_coordinates(&j, tokens, &new_row->start, &new_row->strand, &new_row->sequence_length);
+            new_row->sequence_name = parse_coordinates(&j, tokens, n_tokens, &new_row->start, &new_row->strand, &new_row->sequence_length);
         } else if(op_type[0] == 's') { // Is substituting a row
             free((*row)->sequence_name); // clean up
-            (*row)->sequence_name = parse_coordinates(&j, tokens, &(*row)->start, &(*row)->strand, &(*row)->sequence_length);            
+            (*row)->sequence_name = parse_coordinates(&j, tokens, n_tokens, &(*row)->start, &(*row)->strand, &(*row)->sequence_length);
         } else if(op_type[0] == 'd') { // Is deleting a row
             // Remove the row from the list of rows
             alignment->row_number--;
@@ -87,11 +103,11 @@ static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, stLi
             // Now delete the row
             alignment_row_destruct(r);
         } else if(op_type[0] == 'g') { // Is making a gap without the sequence specified
-            int64_t gap_length = atol(stList_get(tokens, j++)); // Get the index of the affected row
+            int64_t gap_length = atol(tokens[j++]); // Get the index of the affected row
             (*row)->start += gap_length;
         } else { // Is making a gap with the sequence specified
             assert(op_type[0] == 'G');
-            (*row)->left_gap_sequence = stString_copy(stList_get(tokens, j++));
+            (*row)->left_gap_sequence = stString_copy(tokens[j++]);
             (*row)->start += strlen((*row)->left_gap_sequence);
         }
     }
@@ -102,16 +118,16 @@ static Alignment *parse_coordinates_and_establish_block(Alignment *p_block, stLi
 /*
  * Parse the base alignment for the column.
  */
-char *get_bases(int64_t column_length, stList *tokens, bool run_length_encode_bases) {
+static char *get_bases(int64_t column_length, char **tokens, int n_tokens, bool run_length_encode_bases) {
     if(run_length_encode_bases) { // Case the bases are encoded using run length encoding
         char *column = st_calloc(column_length+1, sizeof(char));
         column[column_length] = '\0'; // Make into a properly terminated string
         int64_t i=0, j=0;
         while(j < column_length) {
-            assert(i < stList_length(tokens));
-            char *base_token = stList_get(tokens, i++);
+            assert(i < n_tokens);
+            char *base_token = tokens[i++];
             assert(strlen(base_token) == 1); // The base must be a single character
-            int64_t k = atol(stList_get(tokens, i++));
+            int64_t k = atol(tokens[i++]);
             assert(k > 0); // Each count must be greater than zero
             while(k-- > 0) {
                 column[j++] = base_token[0];
@@ -124,107 +140,94 @@ char *get_bases(int64_t column_length, stList *tokens, bool run_length_encode_ba
         return column;
     }
     // Otherwise column is just a string of bases without whitespace
-    char *column = stString_copy(stList_get(tokens, 0));
+    char *column = stString_copy(tokens[0]);
     assert(strlen(column) == column_length); // Must be a contiguous run of bases equal in length to the number of rows
     return column;
 }
 
 /*
- * Gets the first non-empty line, return NULL if reaches end of file
+ * Gets the first non-empty line, return NULL if reaches end of file.
+ * The returned string must be freed by the caller.
  */
-static stList *get_first_line(LI *li) {
-    stList *tokens = NULL;
-    while(1) { // Loop to find the tokens for the first line
-        // Read column with coordinates first, using previous alignment block and the coordinates
-        // to create the set of rows
-        char *line = LI_get_next_line(li);
-
-        if (line == NULL) { // At end of file
-            return NULL;
-        }
-        // Tokenize the line
-        tokens = stString_split(line);
+static char *get_first_line(LI *li) {
+    char *line;
+    while(1) {
+        line = LI_get_next_line(li);
+        if (line == NULL) return NULL;
+        // Check if the line has any non-whitespace content
+        char *p = line;
+        while (*p != '\0' && isspace((unsigned char)*p)) p++;
+        if (*p != '\0') return line;
         free(line);
-
-        if (stList_length(tokens) == 0) { // Is a white space only line, just ignore it
-            stList_destruct(tokens);
-            tokens = NULL;
-            continue;
-        }
-        else { // We have the first line of the block
-            break;
-        }
     }
-    return tokens;
 }
 
-Tag *parse_tags(stList *tokens, int64_t starting_token, char *delimiter);
+Tag *parse_tags(char **tokens, int n_tokens, int64_t starting_token, char *delimiter);
 
-static Tag *parse_tags_for_column(stList *tokens) {
+static Tag *parse_tags_for_column(char **tokens, int n_tokens) {
     int64_t i=0;
-    while(i<stList_length(tokens)) {
-        if(strcmp(stList_get(tokens, i++), "@") == 0) {
+    while(i<n_tokens) {
+        if(strcmp(tokens[i++], "@") == 0) {
             break; // We have found the token representing the start of the tags
         }
     }
-    return parse_tags(tokens, i, ":");
+    return parse_tags(tokens, n_tokens, i, ":");
 }
 
 Alignment *taf_read_block(Alignment *p_block, bool run_length_encode_bases, LI *li) {
-    stList *tokens = get_first_line(li); // Get the first non-empty line
+    char *tokens_buf[MAX_TOKENS];
+    int n_tokens;
+    char *line;
+
+    // Get the first non-empty, non-comment line
     while(1) {
-        if (tokens == NULL) { // If there are no more lines to be had return NULL
-            return NULL;
-        }
-
-        if(((char *) stList_get(tokens, 0))[0] != '#') { // If it is not a comment line
-            break;
-        }
-
-        stList_destruct(tokens); // Clean up the comment line
-        tokens = get_first_line(li); // Get the next line
+        line = get_first_line(li);
+        if(line == NULL) return NULL;
+        n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
+        if(n_tokens == 0) { free(line); continue; } // shouldn't happen, but be safe
+        if(tokens_buf[0][0] != '#') break; // not a comment line
+        free(line); // skip comment line
     }
 
     // Find the coordinates
-    Alignment *block = parse_coordinates_and_establish_block(p_block, tokens);
+    Alignment *block = parse_coordinates_and_establish_block(p_block, tokens_buf, n_tokens);
 
     // Now add in all subsequent columns until we get one with coordinates, which we push back
     stList *alignment_columns = stList_construct3(0, free);
     stList *tag_lists = stList_construct();
-    stList_append(alignment_columns, get_bases(block->row_number, tokens, run_length_encode_bases));
-    stList_append(tag_lists, parse_tags_for_column(tokens)); // Get any tags for the column
-    stList_destruct(tokens); // Clean up the first row
-    while(1) {
-        char *line = LI_peek_at_next_line(li);
+    stList_append(alignment_columns, get_bases(block->row_number, tokens_buf, n_tokens, run_length_encode_bases));
+    stList_append(tag_lists, parse_tags_for_column(tokens_buf, n_tokens)); // Get any tags for the column
+    free(line); // done with first line
 
-        if(line == NULL) { // We have reached the end of the file
+    while(1) {
+        const char *peek = LI_peek_at_next_line(li);
+
+        if(peek == NULL) { // We have reached the end of the file
             break;
         }
 
-        // tokenize the line
-        tokens = stString_split(line);
-
-        if(stList_length(tokens) == 0) { // Is a white space only line, just ignore it
-            free(LI_get_next_line(li)); // pull the line and clean it up
-            stList_destruct(tokens); // clean up
+        // Check for whitespace-only line without consuming it
+        const char *p = peek;
+        while (*p != '\0' && isspace((unsigned char)*p)) p++;
+        if (*p == '\0') {
+            free(LI_get_next_line(li)); // pull and discard the empty line
             continue;
         }
 
-        int64_t i;
-        if(has_coordinates(tokens, &i)) { // If it has coordinates we have reached the end of the block, so break
-            // and don't pull the line
-            stList_destruct(tokens); // clean up
-            break;
-        }
+        // If next line has coordinates we have reached the end of the block; don't consume it
+        if(line_has_coordinates(peek)) break;
+
+        // Consume and process the non-coordinate line
+        line = LI_get_next_line(li);
+        n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
 
         // Add the bases from the line as a column to the alignment
-        stList_append(alignment_columns, get_bases(block->row_number, tokens, run_length_encode_bases));
+        stList_append(alignment_columns, get_bases(block->row_number, tokens_buf, n_tokens, run_length_encode_bases));
 
         // Parse the tags for the column
-        stList_append(tag_lists, parse_tags_for_column(tokens)); // Get any tags for the column
+        stList_append(tag_lists, parse_tags_for_column(tokens_buf, n_tokens)); // Get any tags for the column
 
-        free(LI_get_next_line(li)); // pull the line and clean up the memory for the line
-        stList_destruct(tokens); // clean up the tokens
+        free(line);
     }
 
     // Set the column number
@@ -264,14 +267,15 @@ Alignment *taf_read_block(Alignment *p_block, bool run_length_encode_bases, LI *
     return block;
 }
 
-Tag *parse_header(stList *tokens, char *header_prefix, char *delimiter);
+Tag *parse_header(char **tokens, int n_tokens, char *header_prefix, char *delimiter);
 
 Tag *taf_read_header(LI *li) {
-    stList *tokens = get_first_line(li);
-    assert(tokens != NULL); // There has to be a valid header line
-    Tag *tag = parse_header(tokens, "#taf", ":");
-    stList_destruct(tokens);
-
+    char *line = get_first_line(li);
+    assert(line != NULL); // There has to be a valid header line
+    char *tokens_buf[MAX_TOKENS];
+    int n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
+    Tag *tag = parse_header(tokens_buf, n_tokens, "#taf", ":");
+    free(line);
     return tag;
 }
 
@@ -429,21 +433,20 @@ void taf_write_header(Tag *tag, LW *lw) {
 int check_input_format(const char *header_line) {
     int ret = 2;
     assert(header_line != NULL);
-    stList *tokens = stString_split(header_line);
-    if (stList_length(tokens) > 0) {
-        if (strcmp(stList_get(tokens, 0), "#taf") == 0) {
-            ret = 0;
-        } else if (strcmp(stList_get(tokens, 0), "##maf") == 0) {
-            ret = 1;
-        }
-    }            
-    stList_destruct(tokens);
-#ifndef USE_HTSLIB   
+    // Skip leading whitespace and check the first token without allocating
+    const char *p = header_line;
+    while (isspace((unsigned char)*p)) p++;
+    if (strncmp(p, "#taf", 4) == 0 && (p[4] == '\0' || isspace((unsigned char)p[4]))) {
+        ret = 0;
+    } else if (strncmp(p, "##maf", 5) == 0 && (p[5] == '\0' || isspace((unsigned char)p[5]))) {
+        ret = 1;
+    }
+#ifndef USE_HTSLIB
     if (ret == 2 && strlen(header_line) >= 2 &&
         (unsigned char)header_line[0] == 0x1f && (unsigned char)header_line[1] == 0x8b) {
         fprintf(stderr, "(b)gzipped input support disabled: please build TAFFY with htslib\n");
         exit(1);
-    }     
+    }
 #endif
     return ret;
 }

--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -2,7 +2,6 @@
 #include "tai.h"
 #include "htslib/bgzf.h"
 #include "htslib/kstring.h"
-#include <ctype.h>
 #include <time.h>
 
 char *tai_path(const char *taf_path) {
@@ -60,10 +59,10 @@ char *tai_parse_region(const char *region, int64_t *start, int64_t *length) {
 // but only returns everything if there's a coordinate for every row in the column
 // this can happen when everything is an "i" like on the first line
 // or when everything is an "s" like on a repeat-coordinates-every-n-columns line
-static char *parse_coordinates_line(stList *tokens, int64_t *start, bool *strand,
+static char *parse_coordinates_line(char **tokens, int n_tokens, int64_t *start, bool *strand,
                                     bool run_length_encode_bases) {
     int64_t j = -1;
-    if (!has_coordinates(tokens, &j)) {
+    if (!has_coordinates(tokens, n_tokens, &j)) {
         return NULL;
     }
 
@@ -72,35 +71,34 @@ static char *parse_coordinates_line(stList *tokens, int64_t *start, bool *strand
     if (run_length_encode_bases) {
         assert(j > 1);
         for (int64_t i = 0; i < j; ++i) {
-            char *token = (char*)stList_get(tokens, i);
+            char *token = tokens[i];
             if (isdigit(token[0])) {
                 num_bases += atol(token);
             }
         }
     } else {
         assert(j == 1);
-        num_bases = strlen(stList_get(tokens, 0));
+        num_bases = strlen(tokens[0]);
     }
     int64_t num_coordinates = 0;
     char *seq = NULL;
     int64_t sequence_length;
     bool dummy;
-    int64_t n = stList_length(tokens);
 
     ++j;
-    while (j < n && strcmp(stList_get(tokens, j), "@") != 0) {
+    while (j < n_tokens && strcmp(tokens[j], "@") != 0) {
         // copied from taf.c
-        char *op_type = stList_get(tokens, j++); // This is the operation
+        char *op_type = tokens[j++]; // This is the operation
         assert(strlen(op_type) == 1); // Must be a single character in length
-        int64_t row_index = atol(stList_get(tokens, j++)); // Get the index of the affected row
+        int64_t row_index = atol(tokens[j++]); // Get the index of the affected row
         if(op_type[0] == 'i' || op_type[0] == 's') { // We have coordinates!
             num_coordinates++;
             if (row_index == 0) {
-                seq = parse_coordinates(&j, tokens, start, strand, &sequence_length);
+                seq = parse_coordinates(&j, tokens, n_tokens, start, strand, &sequence_length);
             } else {
                 // we parse but don't use
                 // todo: smoother api
-                char *s = parse_coordinates(&j, tokens, &sequence_length, &dummy, &sequence_length);
+                char *s = parse_coordinates(&j, tokens, n_tokens, &sequence_length, &dummy, &sequence_length);
                 free(s);
             }
         } else if (op_type[0] == 'd') {
@@ -126,27 +124,32 @@ static char *parse_coordinates_line(stList *tokens, int64_t *start, bool *strand
 // want to start new block parsers on these lines, we have to
 // convert the s's to i's to pretend we're starting new files
 static void change_s_coordinates_to_i(char *line) {
-    stList* tokens = stString_split(line);
+    // Tokenize a copy so that 'line' is only rewritten when found_s is true.
+    // This avoids leaving NUL bytes in 'line' (which is li->line) if no
+    // reconstruction is needed, which would corrupt subsequent tokenization.
+    char *line_copy = stString_copy(line);
+    char *tokens_buf[MAX_TOKENS];
+    int n_tokens = tokenize_line(line_copy, tokens_buf, MAX_TOKENS);
 
     int64_t j = -1;
-    bool hc = has_coordinates(tokens, &j);
+    bool hc = has_coordinates(tokens_buf, n_tokens, &j);
     int64_t dummy_int;
     bool dummy_bool;
     bool found_s = false;
 
     if (hc) {
-        int64_t n = stList_length(tokens);
-        bool *mask = st_calloc(n, sizeof(bool));        
+        bool mask[MAX_TOKENS];
+        memset(mask, 0, n_tokens * sizeof(bool));
         ++j;
-        while (j < n && strcmp(stList_get(tokens, j), "@") != 0) {
-            char *op_type = stList_get(tokens, j++); // This is the operation
-            j++; // the row index;
+        while (j < n_tokens && strcmp(tokens_buf[j], "@") != 0) {
+            char *op_type = tokens_buf[j++]; // This is the operation
+            j++; // the row index
             assert(strlen(op_type) == 1); // Must be a single character in length
             if(op_type[0] == 'i' || op_type[0] == 's') { // We have coordinates!
                 found_s = found_s || op_type[0] == 's';
                 op_type[0] = 'i';
                 // only parse to increment j (would rather use api than just add 4)
-                parse_coordinates(&j, tokens, &dummy_int, &dummy_bool, &dummy_int);
+                parse_coordinates(&j, tokens_buf, n_tokens, &dummy_int, &dummy_bool, &dummy_int);
             } else if (op_type[0] == 'd') {
                 mask[j-2] = true;
                 mask[j-1] = true;
@@ -163,44 +166,42 @@ static void change_s_coordinates_to_i(char *line) {
                 j++;
             }
         }
-        
+
         if (found_s) {
-            // overwrite our line
-            int64_t line_len = strlen(line);
+            // Reconstruct the line in-place from the non-masked tokens.
+            // Uses memmove to handle the overlapping source/destination buffers safely.
             int64_t k = 0;
-            int64_t n = stList_length(tokens);
-            assert(mask[0] == false);
-            for (j = 0; j < n; ++j) {
-                char *token = (char*)stList_get(tokens, j);
-                if (mask[j] == false) {
+            for (j = 0; j < n_tokens; ++j) {
+                if (!mask[j]) {
+                    char *token = tokens_buf[j];
                     int64_t token_len = strlen(token);
-                    char *spacer = j == 0 ? "" : " ";
-                    assert(k + token_len + strlen(spacer) <= line_len);
-                    sprintf(line + k, "%s%s", spacer, token);
-                    k += strlen(token) + strlen(spacer);
+                    if (j > 0) line[k++] = ' ';
+                    memmove(line + k, token, token_len);
+                    k += token_len;
                 }
             }
+            line[k] = '\0';
         }
     } else {
         fprintf(stderr, "Error loading coordinates from indexed taf line: %s\n", line);
         exit(1);
     }
-
-    stList_destruct(tokens);
+    free(line_copy);
 }
 
 static int tai_create_taf(LI *li, FILE *idx_fh, int64_t index_block_size, bool run_length_encode_bases) {
     char *prev_ref = NULL;
     int64_t prev_pos = 0;
     int64_t prev_file_pos = 0;
+    char *tokens_buf[MAX_TOKENS];
 
     // scan the taf line by line
     for (char *line = LI_get_next_line(li); line != NULL; line = LI_get_next_line(li)) {
-        stList* tokens = stString_split(line);
+        int n_tokens = tokenize_line(line, tokens_buf, MAX_TOKENS);
         int64_t pos;
         assert(sizeof(int64_t) == sizeof(off_t));
         bool strand;
-        char *ref = parse_coordinates_line(tokens, &pos, &strand, run_length_encode_bases);
+        char *ref = parse_coordinates_line(tokens_buf, n_tokens, &pos, &strand, run_length_encode_bases);
         if (ref != NULL) {
             // shouldn't need to handle negative strand on reference, right?
             assert(strand == true);
@@ -220,9 +221,10 @@ static int tai_create_taf(LI *li, FILE *idx_fh, int64_t index_block_size, bool r
                 prev_ref = ref;
                 prev_pos = pos;
                 prev_file_pos = file_pos;
+            } else {
+                free(ref);
             }
         }
-        stList_destruct(tokens);
         free(line);
     }
     free(prev_ref);

--- a/taffy/inc/line_iterator.h
+++ b/taffy/inc/line_iterator.h
@@ -67,6 +67,8 @@ typedef struct _LW {
     FILE *fh;
 #ifdef USE_HTSLIB
     BGZF *bgzf;
+    char *buf;
+    size_t buf_cap;
 #endif
 } LW;
 
@@ -78,6 +80,8 @@ LW *LW_construct(FILE *fh, bool use_compression);
 void LW_destruct(LW *lw, bool clean_up_file_handle);
 
 int LW_write(LW *lw, const char *string, ...);
+
+int LW_write_bytes(LW *lw, const char *data, int len);
 
 #endif /* STLINE_ITERATOR_H_ */
 

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -4,8 +4,24 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <ctype.h>
 #include "sonLib.h"
 #include "line_iterator.h"
+
+#define MAX_TOKENS 4096
+
+static inline int tokenize_line(char *line, char **out, int max_tokens) {
+    int n = 0;
+    char *p = line;
+    while (*p != '\0' && n < max_tokens) {
+        while (*p != '\0' && isspace((unsigned char)*p)) p++;
+        if (*p == '\0') break;
+        out[n++] = p;
+        while (*p != '\0' && !isspace((unsigned char)*p)) p++;
+        if (*p != '\0') *p++ = '\0';
+    }
+    return n;
+}
 
 /*
  * Structures to represent blocks of an alignment
@@ -244,15 +260,15 @@ void taf_write_block2(Alignment *p_alignment, Alignment *alignment, bool run_len
  * Check if a tokenized TAF line has coordinates (ie search for ;)
  * If coordinates found, the position of the simicolon in the list is set in j
  */
-bool has_coordinates(stList *tokens, int64_t *j);
+bool has_coordinates(char **tokens, int n_tokens, int64_t *j);
 
 /**
  * Parse the coordinates coming after an "i" or "s" field on a TAF line
  * Returns the sequence name (newly allocated) and sets the strand and
- * position and length in the parameters. *j is the position of the "i" 
+ * position and length in the parameters. *j is the position of the "i"
  * or "s" in the tokenized line, and will be incremented for each field read
  */
-char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand,
+char *parse_coordinates(int64_t *j, char **tokens, int n_tokens, int64_t *start, bool *strand,
                         int64_t *sequence_length);
 
 /**

--- a/tests/taf_test.c
+++ b/tests/taf_test.c
@@ -17,7 +17,7 @@ static char *get_random_tags() {
     return tag_string;
 }
 
-Tag *parse_tags(stList *tokens, int64_t starting_token, char *delimiter);
+Tag *parse_tags(char **tokens, int n_tokens, int64_t starting_token, char *delimiter);
 
 void check_tags(CuTest *testCase, Tag *t, Tag *j) {
     while(t != NULL) {
@@ -53,10 +53,11 @@ static void test_taf(CuTest *testCase) {
         alignment->column_tags = st_malloc(sizeof(Tag *) * alignment->column_number);
         for(int64_t i=0; i<alignment->column_number; i++) {
             char *tag_string = get_random_tags();
-            stList *tokens = stString_split(tag_string);
-            alignment->column_tags[i] = parse_tags(tokens, 0, ":");
-            stList_append(column_tags, parse_tags(tokens, 0, ":"));
-            stList_destruct(tokens);
+            char *tokens_buf[MAX_TOKENS];
+            int n_tokens = tokenize_line(tag_string, tokens_buf, MAX_TOKENS);
+            alignment->column_tags[i] = parse_tags(tokens_buf, n_tokens, 0, ":");
+            stList_append(column_tags, parse_tags(tokens_buf, n_tokens, 0, ":"));
+            free(tag_string);
         }
 
         taf_write_block(p_alignment, alignment, run_length_encode_bases, 1000, lw);


### PR DESCRIPTION
## Summary

- Move `tokenize_line` and `MAX_TOKENS` from `taf.c` and `maf.c` into `taf.h` to eliminate code duplication
- Fix `parse_tags`/`parse_header` to use `char**` token API consistently; update related tests
- Optimize `maf_write_block2`: eliminate VLA and redundant double-`vsnprintf` in `LW_write`
- Micro-optimize `get_bases` in `taf.c`: store the base as a `char` directly rather than keeping a pointer to the token string

## Test plan

- [ ] `make test` — C unit tests pass
- [ ] `make python_test` — Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)