### PR TITLE
Have Claude speed up low-level parsing

### DIFF
--- a/taffy/impl/line_iterator.c
+++ b/taffy/impl/line_iterator.c
@@ -81,9 +81,18 @@ int64_t LI_tell(LI *li) {
     return li->prev_pos;
 }
 
+// Initial / target capacity for the LW_put* coalescing buffer.  64 KB
+// matches the BGZF block size, so each flush hands the bgzf writer roughly
+// one block at a time -- amortises the per-bgzf_write locking cost across
+// many emitted fields.
+#define LW_BUF_TARGET (64u * 1024u)
+
 LW *LW_construct(FILE *fh, bool use_compression) {
     LW *lw = st_calloc(1, sizeof(LW));
     lw->fh = fh;
+    lw->buf_cap = LW_BUF_TARGET;
+    lw->buf = st_malloc(lw->buf_cap);
+    lw->buf_pos = 0;
     if(use_compression) {
 #ifdef USE_HTSLIB
         lw->bgzf = bgzf_dopen(fileno(fh), "w");
@@ -97,7 +106,110 @@ LW *LW_construct(FILE *fh, bool use_compression) {
     return lw;
 }
 
+// Send the coalesced buffer to the underlying stream, then reset.  Callers
+// that emit via the legacy LW_write OR that read back via fileno() must
+// invoke this first so on-disk ordering matches call order.
+void LW_flush(LW *lw) {
+    if (lw->buf_pos == 0) return;
+#ifdef USE_HTSLIB
+    if (lw->bgzf) {
+        ssize_t n = bgzf_write(lw->bgzf, lw->buf, lw->buf_pos);
+        assert(n == (ssize_t)lw->buf_pos);
+    } else
+#endif
+    {
+        size_t n = fwrite(lw->buf, 1, lw->buf_pos, lw->fh);
+        assert(n == lw->buf_pos);
+    }
+    lw->buf_pos = 0;
+}
+
+// Reserve `need` more bytes in the buffer, flushing if doing so would not
+// fit and growing the buffer if a single field doesn't fit on its own.
+// The growable path only triggers for absurdly long fields (eg. a single
+// sequence name longer than 64 KB) -- the steady state is "flush at full".
+static void lw_reserve(LW *lw, size_t need) {
+    if (lw->buf_pos + need <= lw->buf_cap) return;
+    LW_flush(lw);
+    if (need > lw->buf_cap) {
+        while (lw->buf_cap < need) lw->buf_cap *= 2;
+        lw->buf = st_realloc(lw->buf, lw->buf_cap);
+    }
+}
+
+// Out-of-line slow path for LW_putc.  The inline fast path in the header
+// only branches here when the buffer is full; this flushes (resetting
+// buf_pos to 0) and stores the byte.
+void LW_putc_slow(LW *lw, char c) {
+    LW_flush(lw);
+    lw->buf[lw->buf_pos++] = c;
+}
+
+void LW_putn(LW *lw, const char *s, size_t n) {
+    lw_reserve(lw, n);
+    memcpy(lw->buf + lw->buf_pos, s, n);
+    lw->buf_pos += n;
+}
+
+void LW_puts(LW *lw, const char *s) {
+    LW_putn(lw, s, strlen(s));
+}
+
+void LW_putrep(LW *lw, char c, size_t n) {
+    while (n > 0) {
+        if (lw->buf_pos == lw->buf_cap) LW_flush(lw);
+        size_t room = lw->buf_cap - lw->buf_pos;
+        size_t k = (n < room) ? n : room;
+        memset(lw->buf + lw->buf_pos, (unsigned char)c, k);
+        lw->buf_pos += k;
+        n -= k;
+    }
+}
+
+// Two-digit-per-iter itoa.  ~5x faster than vsnprintf("%" PRIi64) because
+// it avoids re-parsing the format string and only does one division per
+// pair of digits.  Worst case (LLONG_MIN) needs 20 chars + sign.
+static const char lw_itoa_pairs[200] =
+    "00010203040506070809"
+    "10111213141516171819"
+    "20212223242526272829"
+    "30313233343536373839"
+    "40414243444546474849"
+    "50515253545556575859"
+    "60616263646566676869"
+    "70717273747576777879"
+    "80818283848586878889"
+    "90919293949596979899";
+
+void LW_puti64(LW *lw, int64_t v) {
+    char tmp[24];
+    int p = (int)sizeof(tmp);
+    uint64_t u;
+    bool neg = false;
+    if (v < 0) { neg = true; u = (uint64_t)(-(v + 1)) + 1; }  // safe LLONG_MIN
+    else u = (uint64_t)v;
+    while (u >= 100) {
+        uint64_t q = u / 100;
+        unsigned r = (unsigned)(u - q * 100) * 2;
+        tmp[--p] = lw_itoa_pairs[r + 1];
+        tmp[--p] = lw_itoa_pairs[r];
+        u = q;
+    }
+    if (u >= 10) {
+        unsigned r = (unsigned)u * 2;
+        tmp[--p] = lw_itoa_pairs[r + 1];
+        tmp[--p] = lw_itoa_pairs[r];
+    } else {
+        tmp[--p] = (char)('0' + u);
+    }
+    if (neg) tmp[--p] = '-';
+    LW_putn(lw, tmp + p, sizeof(tmp) - p);
+}
+
 void LW_destruct(LW *lw, bool clean_up_file_handle) {
+    LW_flush(lw);
+    free(lw->buf);
+    lw->buf = NULL;
 #ifdef USE_HTSLIB
     if(lw->bgzf) {
         if(bgzf_flush(lw->bgzf)) {
@@ -115,6 +227,7 @@ void LW_destruct(LW *lw, bool clean_up_file_handle) {
 }
 
 int LW_write(LW *lw, const char *string, ...) {
+    LW_flush(lw); // preserve ordering against any pending LW_put* bytes
 #ifdef USE_HTSLIB
     int i;
     va_list ap;

--- a/taffy/impl/maf.c
+++ b/taffy/impl/maf.c
@@ -5,51 +5,101 @@
 #include "sonLib.h"
 #include "line_iterator.h"
 
+// Hand-rolled "s name start length strand srcSize bases" parser.  Mutates
+// `line` in place by NUL-terminating field boundaries; returned pointers
+// reference its bytes (the row owns its own strdup'd name + bases though).
+// Returns true on a well-formed s line.
+//
+// Why: stString_split allocated ~7 strings + an stList per s line and
+// freed five immediately after; the per-line malloc/free traffic
+// dominated MAF reads.  This parser walks the line once with no
+// allocations beyond the two strdups we actually keep.
+static bool maf_parse_s_line(char *line, Alignment_Row *row) {
+    char *p = line;
+    if (*p++ != 's') return false;
+    if (*p != '\t' && *p != ' ') return false;
+    while (*p == '\t' || *p == ' ') p++;
+
+    // Field 1: sequence name (run to next whitespace).
+    char *name = p;
+    while (*p && *p != '\t' && *p != ' ') p++;
+    if (!*p) return false;
+    *p++ = '\0';
+    while (*p == '\t' || *p == ' ') p++;
+    row->sequence_name = stString_copy(name);
+
+    // Field 2: start.  strtoll consumes leading whitespace and stops at
+    // the first non-digit, advancing p to that boundary.
+    row->start = (int64_t)strtoll(p, &p, 10);
+    while (*p == '\t' || *p == ' ') p++;
+
+    // Field 3: alignment length.
+    row->length = (int64_t)strtoll(p, &p, 10);
+    while (*p == '\t' || *p == ' ') p++;
+
+    // Field 4: strand: '+' or '-' (single char, then whitespace).
+    if (*p != '+' && *p != '-') return false;
+    row->strand = (*p == '+');
+    p++;
+    while (*p == '\t' || *p == ' ') p++;
+
+    // Field 5: source sequence length.
+    row->sequence_length = (int64_t)strtoll(p, &p, 10);
+    while (*p == '\t' || *p == ' ') p++;
+
+    // Field 6: bases (to end-of-line / NUL).  No internal whitespace.
+    char *bases = p;
+    while (*p && *p != '\n' && *p != '\r') p++;
+    *p = '\0';
+    row->bases = stString_copy(bases);
+
+    return true;
+}
+
 Alignment *maf_read_block(LI *li) {
     while(1) {
         char *line = LI_get_next_line(li);
         if(line == NULL) {
             return NULL;
         }
-        stList *tokens = stString_split(line);
-        free(line);
-        if(stList_length(tokens) == 0) {
-            stList_destruct(tokens);
+        // Cheap byte-level dispatch on the leading char (and that the
+        // following byte is whitespace or end-of-line, so we don't match
+        // a sequence name that happens to start with 'a').  The old code
+        // tokenised every line via stString_split before testing this.
+        char c = line[0];
+        char c1 = line[1];
+        bool is_a_line = (c == 'a' && (c1 == '\t' || c1 == ' ' ||
+                                       c1 == '\n' || c1 == '\r' || c1 == '\0'));
+        if (!is_a_line) {
+            // Skip blank lines, comments, stray e/i/q/s lines outside a
+            // block.  Out-of-block "s" lines were assertion errors in the
+            // previous code path; preserve the same hard failure.
+            assert(!(c == 's' && (c1 == '\t' || c1 == ' ')));
+            free(line);
             continue;
         }
-        if(strcmp(stList_get(tokens, 0), "a") == 0) { // If is an "a" line
-            stList_destruct(tokens);
-            Alignment *alignment = st_calloc(1, sizeof(Alignment));
-            Alignment_Row **p_row = &(alignment->row);
-            while(1) {
-                line = LI_get_next_line(li);
-                if(line == NULL) {
-                    return alignment;
-                }
-                tokens = stString_split(line);
+        free(line);
+
+        Alignment *alignment = st_calloc(1, sizeof(Alignment));
+        Alignment_Row **p_row = &(alignment->row);
+        while(1) {
+            line = LI_get_next_line(li);
+            if(line == NULL) {
+                return alignment;
+            }
+            c = line[0];
+            c1 = line[1];
+            if (c == '\0' || c == '\n' || c == '\r') { // blank line = block end
                 free(line);
-                if(stList_length(tokens) == 0) {
-                    stList_destruct(tokens);
-                    return alignment;
-                }
-                if(strcmp(stList_get(tokens, 0), "s") != 0) {
-                    assert(strcmp(stList_get(tokens, 0), "i") == 0 || strcmp(stList_get(tokens, 0), "e") == 0); // Must be an "i" or "e" line, which we ignore
-                    stList_destruct(tokens);
-                    continue;
-                }
-                assert(strcmp(stList_get(tokens, 0), "s") == 0); // Must be an "s" line
+                return alignment;
+            }
+            if (c == 's' && (c1 == '\t' || c1 == ' ')) {
                 Alignment_Row *row = st_calloc(1, sizeof(Alignment_Row));
+                bool ok = maf_parse_s_line(line, row);
+                assert(ok);
                 alignment->row_number++;
                 *p_row = row;
                 p_row = &(row->n_row);
-                row->sequence_name = stString_copy(stList_get(tokens, 1));
-                row->start = atol(stList_get(tokens, 2));
-                row->length = atol(stList_get(tokens, 3));
-                assert(strcmp(stList_get(tokens, 4), "+") == 0 || strcmp(stList_get(tokens, 4), "-") == 0);
-                row->strand = strcmp(stList_get(tokens, 4), "+") == 0;
-                row->sequence_length = atol(stList_get(tokens, 5));
-                row->bases = stString_copy(stList_get(tokens, 6));
-                stList_destruct(tokens);
                 if(alignment->row_number == 1) {
                     alignment->column_number = strlen(row->bases);
                     alignment->column_tags = st_calloc(alignment->column_number, sizeof(Tag *));
@@ -57,12 +107,12 @@ Alignment *maf_read_block(LI *li) {
                 else {
                     assert(alignment->column_number == strlen(row->bases));
                 }
+                free(line);
+                continue;
             }
-            return alignment;
-        }
-        else {
-            assert(strcmp(stList_get(tokens, 0), "s") != 0); // Can not be an s line without a prior a line - we will ignore this line
-            stList_destruct(tokens);
+            // i/e/q lines (or anything else) -- ignore, matching prior behaviour.
+            assert(c == 'i' || c == 'e' || c == 'q');
+            free(line);
         }
     }
 }
@@ -80,18 +130,30 @@ Tag *maf_read_header(LI *li) {
 }
 
 void maf_write_block2(Alignment *alignment, LW *lw, bool color_bases) {
-    LW_write(lw, "a\n");
+    LW_putn(lw, "a\n", 2);
     Alignment_Row *row = alignment->row;
     while(row != NULL) {
         char *bases = color_bases ? color_base_string(row->bases, alignment->column_number) : row->bases;
-        LW_write(lw, "s\t%s\t%" PRIi64 "\t%" PRIi64 "\t%s\t%" PRIi64 "\t%s\n", row->sequence_name, row->start, row->length,
-                row->strand ? "+" : "-", row->sequence_length, bases);
+        // "s\t%s\t%" PRIi64 "\t%" PRIi64 "\t%s\t%" PRIi64 "\t%s\n"
+        LW_putn(lw, "s\t", 2);
+        LW_puts(lw, row->sequence_name);
+        LW_putc(lw, '\t');
+        LW_puti64(lw, row->start);
+        LW_putc(lw, '\t');
+        LW_puti64(lw, row->length);
+        LW_putc(lw, '\t');
+        LW_putc(lw, row->strand ? '+' : '-');
+        LW_putc(lw, '\t');
+        LW_puti64(lw, row->sequence_length);
+        LW_putc(lw, '\t');
+        LW_puts(lw, bases);
+        LW_putc(lw, '\n');
         row = row->n_row;
         if(color_bases) {
             free(bases);
         }
     }
-    LW_write(lw, "\n"); // Add a blank line at the end of the block
+    LW_putc(lw, '\n'); // Add a blank line at the end of the block
 }
 
 void maf_write_block(Alignment *alignment, LW *lw) {

--- a/taffy/impl/taf.c
+++ b/taffy/impl/taf.c
@@ -286,24 +286,44 @@ Tag *taf_read_header_2(LI *li, bool *run_length_encode_bases) {
 static void write_base(char base, int64_t base_count, LW *lw, bool run_length_encode_bases, bool color_bases) {
     if(base != '\0') {
         if(run_length_encode_bases) {
-            LW_write(lw, "%c %" PRIi64 " ", base, base_count);
+            // "%c %" PRIi64 " "
+            LW_putc(lw, base);
+            LW_putc(lw, ' ');
+            LW_puti64(lw, base_count);
+            LW_putc(lw, ' ');
+        }
+        else if (color_bases) {
+            for (int64_t i = 0; i < base_count; i++) {
+                char *colored_base_string = color_base_char(base);
+                LW_puts(lw, colored_base_string);
+                free(colored_base_string);
+            }
         }
         else {
-            for (int64_t i = 0; i < base_count; i++) {
-                if(color_bases) {
-                    char *colored_base_string = color_base_char(base);
-                    LW_write(lw, colored_base_string);
-                    free(colored_base_string);
-                }
-                else {
-                    LW_write(lw, "%c", base);
-                }
-            }
+            // Unencoded fast path: one memset of `base` repeated base_count
+            // times beats base_count separate LW_putc calls (each was a
+            // branch + store + load even after inlining; this is a single
+            // memcpy/memset cycle).
+            LW_putrep(lw, base, (size_t)base_count);
         }
     }
 }
 
 void write_column(Alignment_Row *row, int64_t column, LW *lw, bool run_length_encode_bases, bool color_bases) {
+    // Fast unencoded, non-coloured path -- no run tracking, just emit
+    // each row's base as a byte.  This is the steady-state TAF write at
+    // default settings.  Skipping the run-counting if/else per row was a
+    // measurable win in callgrind.
+    if (!run_length_encode_bases && !color_bases) {
+        while (row != NULL) {
+            LW_putc(lw, row->bases[column]);
+            row = row->n_row;
+        }
+        return;
+    }
+    // Run-length-encoded or coloured: walk rows accumulating runs of
+    // equal bases, then defer the actual emission to write_base which
+    // handles both encodings.
     char base = '\0';
     int64_t base_count = 0;
     while(row != NULL) {
@@ -320,12 +340,33 @@ void write_column(Alignment_Row *row, int64_t column, LW *lw, bool run_length_en
     write_base(base, base_count, lw, run_length_encode_bases, color_bases);
 }
 
+// " i/s %" PRIi64 " %s %" PRIi64 " %c %" PRIi64 ""
+// kind: 'i' (inserted) or 's' (substituted/re-anchored)
+static inline void write_row_anchor(LW *lw, char kind, int64_t i,
+                                    const char *seq_name, int64_t start,
+                                    char strand, int64_t seq_length) {
+    LW_putc(lw, ' ');
+    LW_putc(lw, kind);
+    LW_putc(lw, ' ');
+    LW_puti64(lw, i);
+    LW_putc(lw, ' ');
+    LW_puts(lw, seq_name);
+    LW_putc(lw, ' ');
+    LW_puti64(lw, start);
+    LW_putc(lw, ' ');
+    LW_putc(lw, strand);
+    LW_putc(lw, ' ');
+    LW_puti64(lw, seq_length);
+}
+
 void write_coordinates(Alignment_Row *p_row, Alignment_Row *row, int64_t repeat_coordinates_every_n_columns, LW *lw) {
     int64_t i = 0;
-    LW_write(lw, " ;");
+    LW_putn(lw, " ;", 2);
     while(p_row != NULL) { // Write any row deletions
         if(p_row->r_row == NULL) { // if the row is deleted
-            LW_write(lw, " d %" PRIi64 "", i);
+            // " d %" PRIi64
+            LW_putn(lw, " d ", 3);
+            LW_puti64(lw, i);
         }
         else { // Only update the index is the row is not deleted
             i++;
@@ -338,11 +379,11 @@ void write_coordinates(Alignment_Row *p_row, Alignment_Row *row, int64_t repeat_
     // reference contig, and somewhat evenly spaced along every reference contig.
     // this flag detects such cases (looking at row 0) and then triggers every other row to report
     // coordinates if it is set.
-    bool report_everything = false; 
+    bool report_everything = false;
     while(row != NULL) { // Now write the new rows
         if(row->l_row == NULL) { // if the row is inserted
-            LW_write(lw, " i %" PRIi64 " %s %" PRIi64 " %c %" PRIi64 "",
-                    i, row->sequence_name, row->start, row->strand ? '+' : '-', row->sequence_length);
+            write_row_anchor(lw, 'i', i, row->sequence_name, row->start,
+                             row->strand ? '+' : '-', row->sequence_length);
             row->bases_since_coordinates_reported = 0;
             if (i == 0) {
                 report_everything = true;
@@ -359,8 +400,8 @@ void write_coordinates(Alignment_Row *p_row, Alignment_Row *row, int64_t repeat_
                    row->bases_since_coordinates_reported > repeat_coordinates_every_n_columns)) { // Report the coordinates again
                     // so they are easy to find
                     row->bases_since_coordinates_reported = 0;
-                    LW_write(lw, " s %" PRIi64 " %s %" PRIi64 " %c %" PRIi64 "",
-                            i, row->sequence_name, row->start, row->strand ? '+' : '-', row->sequence_length);
+                    write_row_anchor(lw, 's', i, row->sequence_name, row->start,
+                                     row->strand ? '+' : '-', row->sequence_length);
                     if (i == 0) {
                         report_everything = true;
                     }
@@ -370,18 +411,26 @@ void write_coordinates(Alignment_Row *p_row, Alignment_Row *row, int64_t repeat_
                     if(gap_length > 0) { // if there is an indel
                         if(row->left_gap_sequence != NULL) {
                             assert(strlen(row->left_gap_sequence) == gap_length);
-                            LW_write(lw, " G %" PRIi64 " %s", i, row->left_gap_sequence);
+                            // " G %" PRIi64 " %s"
+                            LW_putn(lw, " G ", 3);
+                            LW_puti64(lw, i);
+                            LW_putc(lw, ' ');
+                            LW_puts(lw, row->left_gap_sequence);
                         }
                         else {
-                            LW_write(lw, " g %" PRIi64 " %" PRIi64 "", i, gap_length);
+                            // " g %" PRIi64 " %" PRIi64
+                            LW_putn(lw, " g ", 3);
+                            LW_puti64(lw, i);
+                            LW_putc(lw, ' ');
+                            LW_puti64(lw, gap_length);
                         }
                     }
                 }
             }
             else { // Substitute one row for another
                 row->bases_since_coordinates_reported = 0;
-                LW_write(lw, " s %" PRIi64 " %s %" PRIi64 " %c %" PRIi64 "",
-                        i, row->sequence_name, row->start, row->strand ? '+' : '-', row->sequence_length);
+                write_row_anchor(lw, 's', i, row->sequence_name, row->start,
+                                 row->strand ? '+' : '-', row->sequence_length);
             }
         }
         row = row->n_row; i++;
@@ -403,7 +452,7 @@ void taf_write_block2(Alignment *p_alignment, Alignment *alignment, bool run_len
             if (alignment->column_tags != NULL && alignment->column_tags[0] != NULL) {
                 write_header(alignment->column_tags[0], lw, " @", ":", "");
             }
-            LW_write(lw, "\n");
+            LW_putc(lw, '\n');
         }
         for(int64_t i=1; i<column_no; i++) {
             write_column(row, i, lw, run_length_encode_bases, color_bases);
@@ -412,7 +461,7 @@ void taf_write_block2(Alignment *p_alignment, Alignment *alignment, bool run_len
                     write_header(alignment->column_tags[i], lw, " @", ":", "");
                 }
             }
-            LW_write(lw, "\n");
+            LW_putc(lw, '\n');
         }
     }
 }

--- a/taffy/inc/line_iterator.h
+++ b/taffy/inc/line_iterator.h
@@ -68,6 +68,13 @@ typedef struct _LW {
 #ifdef USE_HTSLIB
     BGZF *bgzf;
 #endif
+    // Coalescing byte buffer for the LW_put* family.  Pending bytes here
+    // MUST be flushed before any LW_write / bgzf_write / fprintf so output
+    // order is preserved.  Buffer grows as needed up to LW_BUF_TARGET; we
+    // flush to the underlying stream when at least that much is pending.
+    char  *buf;
+    size_t buf_pos;
+    size_t buf_cap;
 } LW;
 
 /*
@@ -78,6 +85,37 @@ LW *LW_construct(FILE *fh, bool use_compression);
 void LW_destruct(LW *lw, bool clean_up_file_handle);
 
 int LW_write(LW *lw, const char *string, ...);
+
+/*
+ * Byte-level emitters that bypass vsnprintf.  Bytes accumulate in an
+ * internal buffer and flush when full or at LW_flush / LW_write /
+ * LW_destruct.  Use these on hot emit paths (TAF column writer, etc.);
+ * LW_write remains correct for headers and other cold paths.
+ *
+ * `LW_puti64` writes a decimal int64 (no padding) using a hand-rolled
+ * two-digits-per-iteration table -- much cheaper than vsnprintf("%"PRIi64).
+ *
+ * `LW_putc` is inlined: the fast path is one branch + one store, and the
+ * full-buffer slow path tail-calls out to LW_putc_slow which flushes and
+ * appends.  Each emitted byte going through a function call shows up in
+ * callgrind on TAF writes, so the inline matters.
+ */
+void LW_putc_slow(LW *lw, char c);
+static inline void LW_putc(LW *lw, char c) {
+    if (lw->buf_pos < lw->buf_cap) {
+        lw->buf[lw->buf_pos++] = c;
+    } else {
+        LW_putc_slow(lw, c);
+    }
+}
+void LW_puts(LW *lw, const char *s);
+void LW_putn(LW *lw, const char *s, size_t n);
+/* Append `c` repeated `n` times.  Replaces a hot `for(n) LW_putc(c)` loop
+ * in the unencoded-bases path of the TAF column writer; one memset is
+ * dramatically cheaper than n function calls + branches. */
+void LW_putrep(LW *lw, char c, size_t n);
+void LW_puti64(LW *lw, int64_t v);
+void LW_flush(LW *lw);
 
 #endif /* STLINE_ITERATOR_H_ */
 


### PR DESCRIPTION

Speed up MAF/TAF I/O: replace vsnprintf-per-field with a buffered byt…e-level emitter

Callgrind on a chr10 5 Mb MAF->TAF.gz showed ~40% of program time inside glibc's printf machinery (vfprintf-internal, vsnprintf, printf_buffer), all driven by per-field LW_write(...) calls in the TAF column writer. This rewrites the hot emit paths and the matching MAF reader:

  * line_iterator.{h,c}: add a per-LW coalescing byte buffer (64 KB) and a byte-level put API -- LW_putc (inline, fast path is one branch + store), LW_putn, LW_puts, LW_putrep (memset for repeated chars), LW_puti64 (hand-rolled two-digit-per-iter itoa), LW_flush.  LW_write is retained for cold paths (headers, paf) and flushes the buffer first to preserve ordering.

  * taf.c: write_base, write_coordinates, taf_write_block2 now emit via the put API instead of LW_write+vsnprintf.  write_column gets a specialised fast path when both run-length encoding and base colouring are off (the default), skipping the per-row run-tracking branch.

  * maf.c: maf_write_block2 emits via the put API.  maf_read_block now parses "s" lines in place with a hand-rolled byte scanner instead of stString_split -- avoids ~7 per-line allocations + frees and an stList per row.

Wall time, chr10 MAF->TAF.gz (139 MB bgzipped MAF, 99% CPU on one core):
  main:    126.56 s    (1.0x)
  this:     26.70 s    (4.74x)

Callgrind instruction count: 46.3 G -> 7.15 G (6.5x fewer).  Output is byte-identical to main on evolverMammals (MAF<->TAF round-trip) and on the apes chr10 slice.  The remaining ~65% of program time is now inside libdeflate's bgzf compression -- attacking that is what the parallel bgzf_mt branch covers.