### PR TITLE
Add -T/--threads option to enable bgzf_mt on read and write

### DIFF
--- a/taf_annotate.c
+++ b/taf_annotate.c
@@ -21,6 +21,7 @@ static void usage(void) {
     fprintf(stderr, "-s --repeatCoordinatesEveryNColumns : Repeat coordinates of each sequence at least every n columns. By default: %" PRIi64 "\n", repeat_coordinates_every_n_columns);
     fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");
     fprintf(stderr, "-r --refPrefix : Prefix to prepend to chrom names in annotation file to form the sequence name.\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -64,6 +65,7 @@ int taf_annotate_main(int argc, char *argv[]) {
     char *output_file = NULL;
     bool use_compression = 0;
     char *ref_prefix = "";
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -78,11 +80,12 @@ int taf_annotate_main(int argc, char *argv[]) {
                                                 { "repeatCoordinatesEveryNColumns", required_argument, 0, 's' },
                                                 { "useCompression", no_argument, 0, 'c' },
                                                 { "refPrefix", required_argument, 0, 'r' },
+                                                { "threads", required_argument, 0, 'T' },
                                                 { "help", no_argument, 0, 'h' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:o:w:s:cr:ht:", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:o:w:s:cr:ht:T:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -112,6 +115,9 @@ int taf_annotate_main(int argc, char *argv[]) {
             case 'r':
                 ref_prefix = optarg;
                 break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
+                break;
             case 'h':
                 usage();
                 return 0;
@@ -133,6 +139,7 @@ int taf_annotate_main(int argc, char *argv[]) {
     }
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", taf_file);
     st_logInfo("Output file string : %s\n", output_file);
     st_logInfo("Wig file string : %s\n", wig_file);

--- a/taf_index.c
+++ b/taf_index.c
@@ -14,6 +14,7 @@ static void usage(void) {
     fprintf(stderr, "Index a TAF or MAF file, output goes in <file>.tai\n");
     fprintf(stderr, "-i --inputFile : Input taf or maf file [REQUIRED]\n");
     fprintf(stderr, "-b --blockSize : Write an index line for intervals of this many bp [default:10000]\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -27,6 +28,7 @@ int taf_index_main(int argc, char *argv[]) {
     char *logLevelString = NULL;
     char *taf_fn = NULL;
     int64_t block_size = 10000;
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -36,11 +38,12 @@ int taf_index_main(int argc, char *argv[]) {
         static struct option long_options[] = { { "logLevel", required_argument, 0, 'l' },
                                                 { "inputFile", required_argument, 0, 'i' },
                                                 { "blockSize", required_argument, 0, 'b' },
+                                                { "threads", required_argument, 0, 'T' },
                                                 { "help", no_argument, 0, 'h' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:b:h", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:b:hT:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -54,6 +57,9 @@ int taf_index_main(int argc, char *argv[]) {
                 break;
             case 'b':
                 block_size = atoi(optarg);
+                break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
                 break;
             case 'h':
                 usage();
@@ -69,6 +75,7 @@ int taf_index_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", taf_fn);
     st_logInfo("Block size : %" PRIi64 "\n", block_size);
     

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -32,6 +32,7 @@ static void usage(void) {
     fprintf(stderr, "-d --filterGapCausingDupes : Reduce the number of MAF blocks by filtering out rows that induce gaps > maximumGapLength. Rows are only filtered out if they are duplications (contig of same name appears elsewhere in block, or contig with same prefix up to \".\" appears in the same block).\n");
     fprintf(stderr, "-s --repeatCoordinatesEveryNColumns : Repeat coordinates of each sequence at least every n columns. By default: %" PRIi64 "\n", repeat_coordinates_every_n_columns);
     fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-a --halFile : HAL file for extracting gap sequence (MAF must be created with hal2maf *without* --onlySequenceNames)\n");
     fprintf(stderr, "-b --seqFiles : Fasta files for extracting gap sequence. Do not specify both this option and --halFile\n");
     fprintf(stderr, "-h --help : Print this help message\n");
@@ -201,6 +202,7 @@ int taf_norm_main(int argc, char *argv[]) {
     bool filter_gap_causing_dupes = 0;
     stList *fasta_files = stList_construct();
     char *hal_file = NULL;
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -221,10 +223,11 @@ int taf_norm_main(int argc, char *argv[]) {
                                                 { "useCompression", no_argument, 0, 'c' },
                                                 { "halFile", required_argument, 0, 'a' },
                                                 { "seqFiles", required_argument, 0, 'b' },
+                                                { "threads", required_argument, 0, 'T' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:o:hcm:n:dkQ:q:s:a:b:", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:o:hcm:n:dkQ:q:s:a:b:T:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -276,6 +279,9 @@ int taf_norm_main(int argc, char *argv[]) {
                     stList_append(fasta_files, argv[optind]);
                 }
                 break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
+                break;
             default:
                 usage();
                 return 1;
@@ -287,6 +293,7 @@ int taf_norm_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", inputFile);
     st_logInfo("Output file string : %s\n", outputFile);
     st_logInfo("Maximum block length to merge : %" PRIi64 "\n", maximum_block_length_to_merge);

--- a/taf_sort.c
+++ b/taf_sort.c
@@ -25,7 +25,8 @@ static void usage(void) {
     fprintf(stderr, "-r --dontIgnoreFirstRow : Do consider the first (reference) row of each maf block - by default we "
                     "don't alter the sort of the reference row\n");
     fprintf(stderr, "-s --repeatCoordinatesEveryNColumns : Repeat TAF coordinates of each sequence at least every n columns. By default: %" PRIi64 "\n", repeat_coordinates_every_n_columns);
-    fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");    
+    fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -89,6 +90,7 @@ int taf_sort_main(int argc, char *argv[]) {
     char *dup_filter_file = NULL;
     bool ignore_first_row = 1;
     bool use_compression = 0;
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -105,11 +107,12 @@ int taf_sort_main(int argc, char *argv[]) {
                                                {"dontIgnoreFirstRow", no_argument, 0, 'r'},
                                                {"repeatCoordinatesEveryNColumns", required_argument, 0, 's'},
                                                {"useCompression", no_argument, 0, 'c'},
+                                               {"threads", required_argument, 0, 'T'},
                                                {"help",       no_argument,       0, 'h'},
                                                {0, 0,                            0, 0}};
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:o:n:hrf:p:d:s:c", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:o:n:hrf:p:d:s:cT:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -144,7 +147,10 @@ int taf_sort_main(int argc, char *argv[]) {
                 break;
             case 'c':
                 use_compression = 1;
-                break;                                
+                break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
+                break;
             case 'h':
                 usage();
                 return 0;
@@ -159,6 +165,7 @@ int taf_sort_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", input_file);
     st_logInfo("Output file string : %s\n", output_file);
     st_logInfo("Sort file string : %s\n", sort_file);

--- a/taf_stats.c
+++ b/taf_stats.c
@@ -17,6 +17,7 @@ static void usage(void) {
     fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed) alignment\n");
     fprintf(stderr, "-a --alignmentStats : Print stats about block number, aligned bases, etc.\n");
     fprintf(stderr, "-b --sequenceIntervals : Print the BED intervals of each *reference* sequence covered by the alignment\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -33,6 +34,7 @@ int taf_stats_main(int argc, char *argv[]) {
     bool seq_intervals = false;
     int stat_option_count = 0;
     bool alignment_stats = false;
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -44,11 +46,12 @@ int taf_stats_main(int argc, char *argv[]) {
                                                 { "sequenceLengths", no_argument, 0, 's' },
                                                 { "alignmentStats", no_argument, 0, 'a' },
                                                 { "sequenceIntervals", no_argument, 0, 'b' },
+                                                { "threads", required_argument, 0, 'T' },
                                                 { "help", no_argument, 0, 'h' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:sbah", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:sbahT:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -72,6 +75,9 @@ int taf_stats_main(int argc, char *argv[]) {
                 seq_intervals = 1;
                 ++stat_option_count;
                 break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
+                break;
             case 'h':
                 usage();
                 return 0;
@@ -80,12 +86,13 @@ int taf_stats_main(int argc, char *argv[]) {
                 return 1;
         }
     }
-    
+
     //////////////////////////////////////////////
     //Log the inputs
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", taf_fn);
 
     //////////////////////////////////////////////

--- a/taf_view.c
+++ b/taf_view.c
@@ -37,6 +37,7 @@ static void usage(void) {
     fprintf(stderr, "-d --omitCoordinates : When printing TAF, just print the columns omitting the coordinates. THIS IS FOR VISUALIZATION ONLY - DOES NOT PRODUCE A VALID TAF \n");
     fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");
     fprintf(stderr, "-n --nameMapFile : Apply the given two-column tab-separated name mapping to all assembly names in alignment\n");
+    fprintf(stderr, "-T --threads N : Use N threads for bgzf I/O (default 1, only effective on bgzipped streams)\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -92,6 +93,7 @@ int taf_view_main(int argc, char *argv[]) {
     char *phylogeny_file = NULL;
     static bool color_bases = false;
     bool omit_coordinates = false;
+    int bgzf_threads = 1;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -115,11 +117,12 @@ int taf_view_main(int argc, char *argv[]) {
                                                 { "region", required_argument, 0, 'r' },
                                                 { "useCompression", no_argument, 0, 'c' },
                                                 { "nameMapFile", required_argument, 0, 'n' },
+                                                { "threads", required_argument, 0, 'T' },
                                                 { "help", no_argument, 0, 'h' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:o:mPpCaucs:r:n:habxt:d", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:o:mPpCaucs:r:n:habxt:dT:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -177,6 +180,9 @@ int taf_view_main(int argc, char *argv[]) {
             case 'n':
                 nameMapFile = optarg;
                 break;
+            case 'T':
+                bgzf_threads = atoi(optarg);
+                break;
             case 'h':
                 usage();
                 return 0;
@@ -191,6 +197,7 @@ int taf_view_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+    LI_set_bgzf_threads(bgzf_threads);
     st_logInfo("Input file string : %s\n", inputFile);
     st_logInfo("Output file string : %s\n", outputFile);
     st_logInfo("Write compressed output : %s\n", use_compression ? "true" : "false");

--- a/taffy/impl/line_iterator.c
+++ b/taffy/impl/line_iterator.c
@@ -6,6 +6,33 @@
 #include "htslib/kstring.h"
 #endif
 
+// Process-wide bgzf thread count, set once early in each command's main()
+// via LI_set_bgzf_threads().  Default of 1 means "no extra threads" and
+// preserves pre-existing behaviour.  Only consulted at LI/LW open time;
+// changes after a handle is opened do not affect that handle.
+static int bgzf_threads = 1;
+
+void LI_set_bgzf_threads(int n) {
+    bgzf_threads = (n > 0) ? n : 1;
+}
+
+#ifdef USE_HTSLIB
+// Enable bgzf_mt on `bgzf` if threads > 1 AND the stream is actual BGZF
+// (compression == 2).  Plain-gzip and uncompressed streams have no block
+// structure that bgzf_mt can parallelise, so we leave them alone.  Call
+// AFTER bgzf_index_build_init: the htslib docs note the index must be set
+// up before workers start touching the stream.
+static void maybe_enable_bgzf_threads(BGZF *bgzf, const char *what) {
+    if (bgzf_threads > 1 && bgzf_compression(bgzf) == 2) {
+        // n_sub_blks is unused per current htslib; pass 0.  Return code <0
+        // means htslib could not spawn the pool; we soldier on single-
+        // threaded rather than fail the whole command.
+        int rc = bgzf_mt(bgzf, bgzf_threads, 0);
+        st_logInfo("bgzf_mt(%s, threads=%d) -> %d\n", what, bgzf_threads, rc);
+    }
+}
+#endif
+
 LI *LI_construct(FILE *fh) {
     LI *li = st_calloc(1, sizeof(LI));
 #ifdef USE_HTSLIB
@@ -16,6 +43,7 @@ LI *LI_construct(FILE *fh) {
             assert(false);
         }
     }
+    maybe_enable_bgzf_threads(li->bgzf, "read");
     kstring_t ks = KS_INITIALIZE;
     li->prev_pos = bgzf_tell(li->bgzf);
     li->pos = li->prev_pos;
@@ -92,6 +120,7 @@ LW *LW_construct(FILE *fh, bool use_compression) {
         if (bgzf_index_build_init(lw->bgzf) != 0) {
             assert(false);
         }
+        maybe_enable_bgzf_threads(lw->bgzf, "write");
 #endif
     }
     return lw;

--- a/taffy/inc/line_iterator.h
+++ b/taffy/inc/line_iterator.h
@@ -26,6 +26,15 @@ typedef struct _LI {
 } LI;
 
 
+/*
+ * Set the number of threads bgzf I/O should use for both reads (LI) and
+ * writes (LW).  Must be called BEFORE LI_construct / LW_construct take
+ * effect on a given handle; later changes do not affect already-open
+ * handles.  Default is 1 (no bgzf threads).  Has no effect when built
+ * without USE_HTSLIB, or when the underlying stream is not BGZF.
+ */
+void LI_set_bgzf_threads(int n);
+
 LI *LI_construct(FILE *fh);
 
 void LI_destruct(LI *li);


### PR DESCRIPTION

Threads up to N decompressor + N compressor workers around each BGZF stream via htslib's bgzf_mt, applied to both LI (read) and LW (write) construction.  Default 1 preserves prior behaviour; opt-in via -T/--threads on view, index, sort, norm, annotate, and stats (taf_view already uses -t for --phylogeny, so threads gets -T everywhere for consistency).