### PR TITLE
Have taffy norm remove columns that are entirely gaps

### DIFF
--- a/docs/taffy_utilities.md
+++ b/docs/taffy_utilities.md
@@ -102,6 +102,15 @@ For example, to normalize a maf file do the following:
 option reads in underlying sequence files and is used to
 retrieve any sequences that are unaligned between two blocks that is necessary to include in stitching together adjacent blocks. This uses the same method as `taffy add-gap-bases` to add these unaligned sequences.
 
+`taffy norm` also removes any column that consists entirely of gaps. These are left behind when the
+only row with a base in a column has been filtered out, so it is worth running `taffy norm` after
+dropping rows from an alignment, e.g. after removing a species with `taffy sort -f`:
+
+    taffy view -i MAF_FILE | taffy sort -f FILTER_FILE | taffy norm -k -o out.maf
+
+Removing a gap-only column does not change any row's coordinates, as such a column contains no
+bases.
+
 Note(!), taffy norm will resort the rows alpha-numerically according to sequence name,  as is necessary to successfully merge all mergeable rows. Is the resorting is undesired, pipe the result to taffy sort (see below) to resort, e.g.
 
     taffy view -i MAF_FILE | taffy norm -b SEQUENCE_FILES | taffy sort -n SORT_FILE | taffy view -m

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -19,6 +19,8 @@ static int64_t repeat_coordinates_every_n_columns = 10000;
 static void usage(void) {
     fprintf(stderr, "taffy norm [options]\n");
     fprintf(stderr, "Normalize a taf format alignment to remove small blocks using the -m and -n options to determine what to merge \n");
+    fprintf(stderr, "Any column consisting entirely of gaps is also removed, as can be left behind when the only row "
+                    "with a base in that column has been filtered out upstream.\n");
     fprintf(stderr, "Note, taffy norm will resort the rows alpha-numerically according to sequence name, "
                     "as is necessary to successfully merge all mergeable rows. Is the resorting is undesired, pipe the"
                     "result to taffy sort to resort.\n");
@@ -62,6 +64,24 @@ static Alignment *get_next_block(BlockReader *reader) {
     // Reduce the alignment index
     alignment_index--;
     return block;
+}
+
+/*
+ * As get_next_block, but additionally strips out any column that is entirely gaps. These show up
+ * when the only row with a base in a column has been filtered out upstream (e.g. by taffy sort -f
+ * dropping a species). Stripping here, rather than on the way out, means the merging logic below
+ * sees the true block lengths.
+ */
+static Alignment *get_next_block_and_remove_gap_columns(BlockReader *reader) {
+    Alignment *alignment = get_next_block(reader);
+    if(alignment != NULL) {
+        int64_t columns_removed = alignment_remove_all_gap_columns(alignment);
+        if(columns_removed > 0) {
+            st_logDebug("Removed %" PRIi64 " all-gap columns from a block, leaving %" PRIi64 " columns\n",
+                        columns_removed, alignment->column_number);
+        }
+    }
+    return alignment;
 }
 
 /**
@@ -351,7 +371,7 @@ int taf_norm_main(int argc, char *argv[]) {
     tag_destruct(tag);
 
     Alignment *alignment, *p_alignment = NULL, *p_p_alignment = NULL;
-    while((alignment = get_next_block(reader)) != NULL) {
+    while((alignment = get_next_block_and_remove_gap_columns(reader)) != NULL) {
         // First resort the rows to be alphabetical and then realign with any previous block. This ensures
         // we will not have any mergeable rows unlinked. Note:
         // We do not allow row substitutions when linking two blocks to merge (see last parameter of function call),
@@ -371,6 +391,8 @@ int taf_norm_main(int argc, char *argv[]) {
                     // try to greedily filter dupes in order to get the gap length down - do this iteratively,
                     // relinking the rows after each step
                     while (max_gap > maximum_gap_length && greedy_prune_by_gap(alignment, maximum_gap_length)) {
+                        alignment_remove_all_gap_columns(alignment); // Dropping rows can leave columns that are
+                        // now entirely gaps
                         alignment_link_adjacent(p_alignment, alignment, 0); // Now relink, as having removed rows we
                         // may have different rows that need to be relinked
                         max_gap = alignment_max_gap_length(p_alignment); // recalculste the max gap

--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -321,6 +321,88 @@ int64_t alignment_number_of_common_rows(Alignment *left_alignment, Alignment *ri
     return shared_rows;
 }
 
+static bool alignment_column_is_all_gaps(Alignment *alignment, int64_t column_index) {
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if(row->bases[column_index] != '-') {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int64_t alignment_remove_all_gap_columns(Alignment *alignment) {
+    int64_t column_number = alignment->column_number;
+    if(alignment->row == NULL || column_number == 0) {
+        return 0;
+    }
+    // Flag the columns to keep. Scanning column-major with an early exit keeps this
+    // O(column_number) in the common case where the first row has a base in every column, and the
+    // flags are only allocated once we know there is a gap-only column to remove.
+    char *keep_column = NULL;
+    int64_t columns_to_remove = 0;
+    for(int64_t i=0; i<column_number; i++) {
+        if(alignment_column_is_all_gaps(alignment, i)) {
+            if(keep_column == NULL) {
+                keep_column = st_calloc(column_number, sizeof(char));
+                for(int64_t j=0; j<i; j++) { // Every column up to here is being kept
+                    keep_column[j] = 1;
+                }
+            }
+            columns_to_remove++;
+        }
+        else if(keep_column != NULL) {
+            keep_column[i] = 1;
+        }
+    }
+    if(keep_column == NULL) { // Nothing to do, which is the usual case
+        return 0;
+    }
+    // If every column is a gap then keep one of them, so that we never reduce a block to zero
+    // columns. Such a block can not be written, and removing it from the alignment instead would
+    // strand the interstitial gap sequence that the following block records relative to it.
+    if(columns_to_remove == column_number) {
+        keep_column[0] = 1;
+        columns_to_remove--;
+    }
+    // Compact the bases of each row in place. Note we deliberately do not touch start / length /
+    // sequence_length or the l_row / r_row links: a gap-only column contains no bases, so removing
+    // it leaves every row's coordinates, and hence the linking between blocks, unchanged.
+    Alignment_Row *row = alignment->row;
+    while(row != NULL) {
+        // Every reader builds bases exactly column_number long, see taf_read_block and maf_read_block
+        assert((int64_t)strlen(row->bases) == column_number);
+        int64_t j=0;
+        for(int64_t i=0; i<column_number; i++) {
+            if(keep_column[i]) {
+                row->bases[j++] = row->bases[i];
+            }
+        }
+        row->bases[j] = '\0';
+        assert(j == column_number - columns_to_remove);
+        row = row->n_row;
+    }
+    // Compact the column tags, cleaning up the tags of the columns being removed
+    if(alignment->column_tags != NULL) {
+        int64_t j=0;
+        for(int64_t i=0; i<column_number; i++) {
+            if(keep_column[i]) {
+                alignment->column_tags[j++] = alignment->column_tags[i];
+            }
+            else {
+                tag_destruct(alignment->column_tags[i]);
+            }
+        }
+        while(j < column_number) { // Null the now unused trailing entries. alignment_destruct only
+            // walks up to the reduced column_number, so this is belt and braces against a future
+            // caller that looks at them
+            alignment->column_tags[j++] = NULL;
+        }
+    }
+    alignment->column_number = column_number - columns_to_remove;
+    free(keep_column);
+    return columns_to_remove;
+}
+
 void alignment_get_column_in_buffer(Alignment *alignment, int64_t column_index, char *buffer) {
     assert(column_index >= 0);
     assert(column_index < alignment->column_number);

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -125,6 +125,16 @@ stList *alignment_get_rows_in_a_list(Alignment_Row *row);
 void alignment_set_rows(Alignment *alignment, stList *rows);
 
 /*
+ * Remove any column of the alignment that consists entirely of gaps, e.g. as left behind when the
+ * only row with a base in that column has been filtered out. The bases of each row and the column
+ * tags are compacted in place and column_number is reduced accordingly. Row coordinates and the
+ * links between adjacent blocks are unaffected, as a gap-only column contains no bases. Returns
+ * the number of columns removed. If every column is a gap then one is kept, so the alignment is
+ * never reduced to zero columns.
+ */
+int64_t alignment_remove_all_gap_columns(Alignment *alignment);
+
+/*
  * Read a column of the alignment into the buffer. The buffer must be initialized and be at least
  * of length alignment->row_number.
  */

--- a/tests/gap_column_filter.txt
+++ b/tests/gap_column_filter.txt
@@ -1,0 +1,1 @@
+simMouse

--- a/tests/gap_column_filter_test.maf
+++ b/tests/gap_column_filter_test.maf
@@ -1,0 +1,6 @@
+##maf version=1 scoring=N/A
+
+a
+s	simCow.chr1	0	6	+	100	AC--GTAC--
+s	simDog.chr1	0	6	+	100	AC--GTAC--
+s	simMouse.chr1	0	10	+	100	ACTTGTACGG

--- a/tests/gap_column_filter_test_truth.maf
+++ b/tests/gap_column_filter_test_truth.maf
@@ -1,0 +1,6 @@
+##maf version=1 scoring=N/A
+
+a
+s	simCow.chr1	0	6	+	100	ACGTAC
+s	simDog.chr1	0	6	+	100	ACGTAC
+

--- a/tests/gap_column_gap_seq_test.taf
+++ b/tests/gap_column_gap_seq_test.taf
@@ -1,0 +1,7 @@
+#taf version:1
+AA ; i 0 s1.c1 0 + 100 i 1 s2.c1 0 + 100
+CC
+-- ; G 0 TTTTT G 1 TTTTT
+--
+GG ; G 0 CCC G 1 CCC
+TT

--- a/tests/gap_column_test.maf
+++ b/tests/gap_column_test.maf
@@ -1,0 +1,14 @@
+##maf version=1 scoring=N/A
+
+a
+s	simCow.chr1	10	4	+	100	-AC-GT--
+s	simDog.chr1	20	4	+	100	-AC-GT--
+s	simHuman.chr1	30	4	+	100	-AC-GT--
+
+a
+s	simCow.chr2	5	3	+	200	AC--G
+s	simDog.chr2	5	3	+	200	AC--G
+
+a
+s	simCow.chr2	8	2	+	200	-TT-
+s	simDog.chr2	8	2	+	200	-TT-

--- a/tests/gap_column_test_truth.maf
+++ b/tests/gap_column_test_truth.maf
@@ -1,0 +1,11 @@
+##maf version=1 scoring=N/A
+
+a
+s	simCow.chr1	10	4	+	100	ACGT
+s	simDog.chr1	20	4	+	100	ACGT
+s	simHuman.chr1	30	4	+	100	ACGT
+
+a
+s	simCow.chr2	5	5	+	200	ACGTT
+s	simDog.chr2	5	5	+	200	ACGTT
+

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -242,8 +242,234 @@ static void test_norm_maf_input(CuTest *testCase) {
     st_system("rm -f %s %s", piped_out, direct_out);
 }
 
+// Checks alignment_remove_all_gap_columns directly: the gap-only columns go, the remaining bases
+// keep their order, the column tags follow the columns they belong to, and the row coordinates are
+// left alone.
+static void test_remove_all_gap_columns(CuTest *testCase) {
+    char *example_file = "./tests/gap_column_test.maf";
+    FILE *file = fopen(example_file, "r");
+    LI *li = LI_construct(file);
+    Tag *header = maf_read_header(li);
+    tag_destruct(header);
+
+    // The first block of the toy file is 8 columns of which 4 (the first, one in the middle and the
+    // last two) are entirely gaps
+    Alignment *alignment = maf_read_block(li);
+    CuAssertTrue(testCase, alignment != NULL);
+    CuAssertIntEquals(testCase, 8, alignment->column_number);
+    CuAssertIntEquals(testCase, 3, alignment->row_number);
+
+    // Tag a column that survives and a column that does not, so we can check the tags are remapped
+    alignment->column_tags[1] = tag_construct("keep", "1", alignment->column_tags[1]);
+    alignment->column_tags[3] = tag_construct("drop", "1", alignment->column_tags[3]);
+
+    // Record the row coordinates so we can check they are untouched
+    int64_t starts[3], lengths[3], sequence_lengths[3];
+    int64_t i = 0;
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row, i++) {
+        starts[i] = row->start;
+        lengths[i] = row->length;
+        sequence_lengths[i] = row->sequence_length;
+    }
+    CuAssertIntEquals(testCase, 3, i);
+
+    CuAssertIntEquals(testCase, 4, alignment_remove_all_gap_columns(alignment));
+    CuAssertIntEquals(testCase, 4, alignment->column_number);
+    CuAssertIntEquals(testCase, 3, alignment->row_number); // No rows are removed
+
+    i = 0;
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row, i++) {
+        CuAssertStrEquals(testCase, "ACGT", row->bases);
+        CuAssertIntEquals(testCase, starts[i], row->start);
+        CuAssertIntEquals(testCase, lengths[i], row->length);
+        CuAssertIntEquals(testCase, sequence_lengths[i], row->sequence_length);
+    }
+    CuAssertIntEquals(testCase, 3, i);
+
+    // The tag of the kept column moved with it from index 1 to index 0, and the tag of the removed
+    // column is gone
+    CuAssertTrue(testCase, tag_find(alignment->column_tags[0], "keep") != NULL);
+    for(int64_t j=0; j<alignment->column_number; j++) {
+        CuAssertTrue(testCase, tag_find(alignment->column_tags[j], "drop") == NULL);
+    }
+
+    // Running it again is a no-op now that no column is all gaps
+    CuAssertIntEquals(testCase, 0, alignment_remove_all_gap_columns(alignment));
+    CuAssertIntEquals(testCase, 4, alignment->column_number);
+
+    alignment_destruct(alignment, 1);
+    LI_destruct(li);
+    fclose(file);
+}
+
+// A block in which every column is a gap keeps one column rather than being reduced to nothing. A
+// zero column block can not be written, and dropping such a block from the alignment instead would
+// strand the interstitial gap sequence that the following block records relative to it.
+static void test_remove_all_gap_columns_all_gap_block(CuTest *testCase) {
+    Alignment *alignment = st_calloc(1, sizeof(Alignment));
+    alignment->column_number = 3;
+    alignment->column_tags = st_calloc(3, sizeof(Tag *));
+    alignment->row_number = 2;
+    Alignment_Row *row_1 = st_calloc(1, sizeof(Alignment_Row));
+    row_1->sequence_name = stString_copy("simCow.chr1");
+    row_1->bases = stString_copy("---");
+    row_1->strand = 1;
+    row_1->sequence_length = 100;
+    Alignment_Row *row_2 = st_calloc(1, sizeof(Alignment_Row));
+    row_2->sequence_name = stString_copy("simDog.chr1");
+    row_2->bases = stString_copy("---");
+    row_2->strand = 1;
+    row_2->sequence_length = 100;
+    alignment->row = row_1;
+    row_1->n_row = row_2;
+
+    CuAssertIntEquals(testCase, 2, alignment_remove_all_gap_columns(alignment));
+    CuAssertIntEquals(testCase, 1, alignment->column_number);
+    CuAssertStrEquals(testCase, "-", row_1->bases);
+    CuAssertStrEquals(testCase, "-", row_2->bases);
+
+    // And it stays at one column if run again
+    CuAssertIntEquals(testCase, 0, alignment_remove_all_gap_columns(alignment));
+    CuAssertIntEquals(testCase, 1, alignment->column_number);
+
+    alignment_destruct(alignment, 1);
+}
+
+/*
+ * A block that is nothing but gaps has to survive as a block, because the block after it records
+ * its interstitial gap sequence (a TAF "G" record) relative to it. Removing the all-gap block
+ * would leave that gap sequence describing a gap that no longer exists, which silently drops the
+ * unaligned bases and leaves each row's length field disagreeing with its aligned bases.
+ */
+static void test_all_gap_block_keeps_gap_sequence(CuTest *testCase) {
+    char *input_file = "./tests/gap_column_gap_seq_test.taf";
+    char *output_file = "./tests/gap_column_gap_seq_out.maf";
+    int i = st_system("./bin/taffy norm -i %s -k -o %s", input_file, output_file);
+    CuAssertIntEquals(testCase, 0, i); // must not abort
+
+    // The two blocks either side of the all-gap block merge, so the 5 bases of gap sequence before
+    // the all-gap block and the 3 before the final block are both part of the merged row
+    FILE *file = fopen(output_file, "r");
+    CuAssertTrue(testCase, file != NULL);
+    LI *li = LI_construct(file);
+    Tag *header = maf_read_header(li);
+    tag_destruct(header);
+    Alignment *alignment = maf_read_block(li);
+    CuAssertTrue(testCase, alignment != NULL);
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        int64_t bases = 0;
+        for(int64_t j=0; j<alignment->column_number; j++) {
+            if(row->bases[j] != '-') {
+                bases++;
+            }
+        }
+        // 2 aligned + 5 unaligned + 3 unaligned + 2 aligned
+        CuAssertIntEquals(testCase, 12, row->length);
+        CuAssertIntEquals(testCase, row->length, bases); // the gap bases must still be there
+    }
+    alignment_destruct(alignment, 1);
+    LI_destruct(li);
+    fclose(file);
+    st_system("rm %s", output_file);
+}
+
+static void test_gap_column_filter(CuTest *testCase) {
+    /*
+     * Run taffy norm on a small maf containing all-gap columns and check they are removed. The toy
+     * file also exercises the interaction with block merging: its second and third blocks are
+     * adjacent on the same contig and get merged, and the merged block must not carry over the gap
+     * columns of either input block.
+     */
+    char *input_file = "./tests/gap_column_test.maf";
+    char *taf_file = "./tests/gap_column_test_out.taf";
+    char *output_file = "./tests/gap_column_test_out.maf";
+    // Run norm as its own command rather than in the middle of a pipeline, so that a norm failure
+    // is not masked by the exit status of the last stage
+    int i = st_system("./bin/taffy view -i %s -o %s", input_file, taf_file);
+    CuAssertIntEquals(testCase, 0, i);
+    int j = st_system("./bin/taffy norm -i %s -k -o %s", taf_file, output_file);
+    CuAssertIntEquals(testCase, 0, j); // return value should be zero
+    char *truth_file = "./tests/gap_column_test_truth.maf";
+    int diff_ret = st_system("diff %s %s", output_file, truth_file);
+    CuAssertIntEquals(testCase, 0, diff_ret); // return value should be zero if files same
+    st_system("rm %s %s", output_file, taf_file);
+}
+
+// Counts the columns of a maf file that consist entirely of gaps, additionally checking that each
+// row's stated length agrees with its number of non-gap bases. The latter is the invariant that
+// removing columns has to preserve: it breaks if we ever drop a column that held a base.
+static int64_t count_all_gap_columns(CuTest *testCase, char *maf_file) {
+    FILE *file = fopen(maf_file, "r");
+    CuAssertTrue(testCase, file != NULL);
+    LI *li = LI_construct(file);
+    Tag *header = maf_read_header(li);
+    tag_destruct(header);
+    int64_t all_gap_columns = 0;
+    Alignment *alignment;
+    while((alignment = maf_read_block(li)) != NULL) {
+        for(int64_t i=0; i<alignment->column_number; i++) {
+            bool all_gaps = true;
+            for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+                if(row->bases[i] != '-') {
+                    all_gaps = false;
+                    break;
+                }
+            }
+            if(all_gaps) {
+                all_gap_columns++;
+            }
+        }
+        for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+            int64_t bases = 0;
+            for(int64_t i=0; i<alignment->column_number; i++) {
+                if(row->bases[i] != '-') {
+                    bases++;
+                }
+            }
+            CuAssertIntEquals(testCase, row->length, bases);
+        }
+        alignment_destruct(alignment, 1);
+    }
+    LI_destruct(li);
+    fclose(file);
+    return all_gap_columns;
+}
+
+// The motivating case: filtering out a species leaves behind the columns that only it had a base
+// in, and norm should clean them up. The toy input gives simMouse two insertions relative to the
+// other two rows, so filtering simMouse out strands four all-gap columns.
+static void test_gap_columns_after_filtering_a_species(CuTest *testCase) {
+    char *input_file = "./tests/gap_column_filter_test.maf";
+    char *filter_file = "./tests/gap_column_filter.txt";
+    char *filtered_file = "./tests/gap_column_filtered.maf";
+    char *normalized_file = "./tests/gap_column_filtered.norm.maf";
+
+    int i = st_system("./bin/taffy view -i %s | ./bin/taffy sort -f %s | ./bin/taffy view -m > %s",
+                      input_file, filter_file, filtered_file);
+    CuAssertIntEquals(testCase, 0, i);
+    int j = st_system("./bin/taffy view -i %s | ./bin/taffy sort -f %s | ./bin/taffy norm -k > %s",
+                      input_file, filter_file, normalized_file);
+    CuAssertIntEquals(testCase, 0, j);
+
+    // Filtering on its own strands the four columns simMouse was the only row with a base in
+    CuAssertIntEquals(testCase, 4, count_all_gap_columns(testCase, filtered_file));
+    // Normalizing afterwards removes all of them
+    CuAssertIntEquals(testCase, 0, count_all_gap_columns(testCase, normalized_file));
+
+    char *truth_file = "./tests/gap_column_filter_test_truth.maf";
+    int diff_ret = st_system("diff %s %s", normalized_file, truth_file);
+    CuAssertIntEquals(testCase, 0, diff_ret);
+
+    st_system("rm -f %s %s", filtered_file, normalized_file);
+}
+
 CuSuite* normalize_test_suite(void) {
     CuSuite* suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_remove_all_gap_columns);
+    SUITE_ADD_TEST(suite, test_remove_all_gap_columns_all_gap_block);
+    SUITE_ADD_TEST(suite, test_all_gap_block_keeps_gap_sequence);
+    SUITE_ADD_TEST(suite, test_gap_column_filter);
+    SUITE_ADD_TEST(suite, test_gap_columns_after_filtering_a_species);
     SUITE_ADD_TEST(suite, test_normalize);
     SUITE_ADD_TEST(suite, test_maf_norm);
     SUITE_ADD_TEST(suite, test_maf_norm_to_maf);


### PR DESCRIPTION
Filtering rows out of an alignment leaves behind any column that only the removed rows had a base in. Nothing downstream cleaned these up, so an all-gap column would survive a round trip and even get carried through a block merge.
