### PR TITLE
Unnormalize

### DIFF
--- a/docs/taffy_utilities.md
+++ b/docs/taffy_utilities.md
@@ -111,6 +111,16 @@ dropping rows from an alignment, e.g. after removing a species with `taffy sort 
 Removing a gap-only column does not change any row's coordinates, as such a column contains no
 bases.
 
+### Unnormalizing
+
+    taffy norm -i MAF_FILE -u -k -o out.maf
+
+`taffy norm -u` does the reverse, splitting each block at every run of columns in which the reference
+(first) row has a gap and removing those columns, which puts an already merged alignment back into the
+reference-contiguous form hal2maf produces. Normalizing and then unnormalizing recovers the same
+alignment columns, though not every block boundary, as two blocks merged with no gap between them
+leave no reference gap to split back on.
+
 Note(!), taffy norm will resort the rows alpha-numerically according to sequence name,  as is necessary to successfully merge all mergeable rows. Is the resorting is undesired, pipe the result to taffy sort (see below) to resort, e.g.
 
     taffy view -i MAF_FILE | taffy norm -b SEQUENCE_FILES | taffy sort -n SORT_FILE | taffy view -m

--- a/docs/taffy_utilities.md
+++ b/docs/taffy_utilities.md
@@ -118,8 +118,9 @@ bases.
 `taffy norm -u` does the reverse, splitting each block at every run of columns in which the reference
 (first) row has a gap and removing those columns, which puts an already merged alignment back into the
 reference-contiguous form hal2maf produces. Normalizing and then unnormalizing recovers the same
-alignment columns, though not every block boundary, as two blocks merged with no gap between them
-leave no reference gap to split back on.
+alignment columns as long as the reference itself is contiguous, as it is in hal2maf output, though
+not every block boundary, since two blocks merged with no gap between them leave no reference gap to
+split back on.
 
 Note(!), taffy norm will resort the rows alpha-numerically according to sequence name,  as is necessary to successfully merge all mergeable rows. Is the resorting is undesired, pipe the result to taffy sort (see below) to resort, e.g.
 

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -32,6 +32,7 @@ static void usage(void) {
     fprintf(stderr, "-n --maximumGapLength : Only merge together two adjacent blocks if the total number of unaligned bases between the blocks is less than this many bases, by default: %" PRIi64 "\n", maximum_gap_length);
     fprintf(stderr, "-Q --minimumSharedRows : The minimum number of rows between two blocks that need to be shared for a merge, default: %" PRIi64 "\n", minimum_shared_rows);
     fprintf(stderr, "-q --fractionSharedRows : The fraction of rows between two blocks that need to be shared for a merge, default: %f\n", fraction_shared_rows);
+    fprintf(stderr, "-u --unnormalize : Reverse of the normal merging: split each block at every run of columns in which the reference (first) row has a gap, removing those columns, so that no output block has a reference gap. The bases in the removed columns are not aligned to the reference and are dropped. Can not be combined with -d, -a or -b, and the -m, -n, -Q and -q merging options are not used.\n");
     fprintf(stderr, "-d --filterGapCausingDupes : Reduce the number of MAF blocks by filtering out rows that induce gaps > maximumGapLength. Rows are only filtered out if they are duplications (contig of same name appears elsewhere in block, or contig with same prefix up to \".\" appears in the same block).\n");
     fprintf(stderr, "-s --repeatCoordinatesEveryNColumns : Repeat coordinates of each sequence at least every n columns. By default: %" PRIi64 "\n", repeat_coordinates_every_n_columns);
     fprintf(stderr, "-c --useCompression : Write the output using bgzip compression.\n");
@@ -207,6 +208,45 @@ static bool greedy_prune_by_gap(Alignment *alignment, int64_t maximum_gap_length
 }
 
 
+/*
+ * Break a block's links to the blocks the reader linked it to. When we write blocks we built
+ * ourselves, an input block can outlive or predecease its reader neighbours, and relinking it into
+ * the output would otherwise leave a neighbour pointing at it without a matching pointer back.
+ */
+static void unlink_block(Alignment *alignment) {
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if(row->l_row != NULL) {
+            row->l_row->r_row = NULL;
+            row->l_row = NULL;
+        }
+        if(row->r_row != NULL) {
+            row->r_row->l_row = NULL;
+            row->r_row = NULL;
+        }
+    }
+}
+
+/*
+ * Push a block onto the output. Blocks are written one behind, because the block after the one being
+ * written has to be linked to it first, and the two previous blocks are kept so that taf coordinates
+ * can be written differentially against them.
+ */
+static void emit_block(Alignment **p_alignment, Alignment **p_p_alignment, Alignment *alignment,
+                       LW *output, bool output_maf, bool run_length_encode_bases,
+                       int64_t repeat_coordinates_every_n_columns) {
+    if(*p_alignment != NULL) {
+        alignment_link_adjacent(*p_alignment, alignment, 1);
+        output_maf ? maf_write_block(*p_alignment, output) :
+            taf_write_block(*p_p_alignment, *p_alignment, run_length_encode_bases,
+                            repeat_coordinates_every_n_columns, output);
+        if(*p_p_alignment != NULL) {
+            alignment_destruct(*p_p_alignment, 1);
+        }
+        *p_p_alignment = *p_alignment;
+    }
+    *p_alignment = alignment;
+}
+
 int taf_norm_main(int argc, char *argv[]) {
     time_t startTime = time(NULL);
 
@@ -220,6 +260,7 @@ int taf_norm_main(int argc, char *argv[]) {
     bool output_maf = 0;
     bool use_compression = 0;
     bool filter_gap_causing_dupes = 0;
+    bool unnormalize = 0;
     stList *fasta_files = stList_construct();
     char *hal_file = NULL;
     int bgzf_threads = 1;
@@ -239,6 +280,7 @@ int taf_norm_main(int argc, char *argv[]) {
                                                 { "fractionSharedRows", required_argument, 0, 'q' },
                                                 { "minimumSharedRows", required_argument, 0, 'Q' },
                                                 { "filterGapCausingDupes", no_argument, 0, 'd' },
+                                                { "unnormalize", no_argument, 0, 'u' },
                                                 { "repeatCoordinatesEveryNColumns", required_argument, 0, 's' },
                                                 { "useCompression", no_argument, 0, 'c' },
                                                 { "halFile", required_argument, 0, 'a' },
@@ -247,7 +289,7 @@ int taf_norm_main(int argc, char *argv[]) {
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:o:hcm:n:dkQ:q:s:a:b:T:", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:o:hcm:n:dukQ:q:s:a:b:T:", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -276,6 +318,9 @@ int taf_norm_main(int argc, char *argv[]) {
                 break;
             case 'd':
                 filter_gap_causing_dupes = 1;
+                break;
+            case 'u':
+                unnormalize = 1;
                 break;
             case 'Q':
                 minimum_shared_rows = atol(optarg);
@@ -311,6 +356,12 @@ int taf_norm_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
     //Log the inputs
     //////////////////////////////////////////////
+
+    if(unnormalize && (filter_gap_causing_dupes || hal_file != NULL || stList_length(fasta_files) > 0)) {
+        fprintf(stderr, "--unnormalize splits blocks apart rather than merging them, so it can not be "
+                        "combined with -d, -a or -b\n");
+        return 1;
+    }
 
     st_setLogLevelFromString(logLevelString);
     LI_set_bgzf_threads(bgzf_threads);
@@ -371,6 +422,61 @@ int taf_norm_main(int argc, char *argv[]) {
     tag_destruct(tag);
 
     Alignment *alignment, *p_alignment = NULL, *p_p_alignment = NULL;
+    if(unnormalize) {
+        //////////////////////////////////////////////
+        // Split every block at its reference gaps, which is the reverse of the merging below
+        //////////////////////////////////////////////
+        int64_t blocks_in = 0, blocks_out = 0, blocks_dropped = 0;
+        while((alignment = get_next_block(reader)) != NULL) {
+            blocks_in++;
+            unlink_block(alignment); // We write blocks of our own making, so the reader's links
+            // between input blocks would only leave dangling pointers behind
+            stList *segments = alignment_split_at_reference_gaps(alignment);
+            if(segments == NULL) { // The reference has no gaps, so the block is already unnormalized
+                emit_block(&p_alignment, &p_p_alignment, alignment, output, output_maf,
+                           run_length_encode_bases, repeat_coordinates_every_n_columns);
+                blocks_out++;
+                continue;
+            }
+            if(stList_length(segments) == 0) { // The reference row was entirely gaps, so nothing in
+                // the block is anchored to the reference and it goes away
+                blocks_dropped++;
+                st_logDebug("Dropping a block whose reference row was entirely gaps\n");
+            }
+            for(int64_t i=0; i<stList_length(segments); i++) {
+                emit_block(&p_alignment, &p_p_alignment, stList_get(segments, i), output, output_maf,
+                           run_length_encode_bases, repeat_coordinates_every_n_columns);
+                blocks_out++;
+            }
+            stList_destruct(segments);
+            alignment_destruct(alignment, 1); // We built new blocks, so the input block goes
+        }
+        // Flush the last block, which has nothing after it to link to
+        if(p_alignment != NULL) {
+            output_maf ? maf_write_block(p_alignment, output) :
+                taf_write_block(p_p_alignment, p_alignment, run_length_encode_bases, -1, output);
+            alignment_destruct(p_alignment, 1);
+            if(p_p_alignment != NULL) {
+                alignment_destruct(p_p_alignment, 1);
+            }
+        }
+        st_logInfo("Unnormalized %" PRIi64 " blocks into %" PRIi64 ", dropping %" PRIi64
+                   " with an all-gap reference row\n", blocks_in, blocks_out, blocks_dropped);
+        block_reader_destruct(reader);
+        LI_destruct(li);
+        if(inputFile != NULL) {
+            fclose(input);
+        }
+        LW_destruct(output, outputFile != NULL);
+        if (fastas_map) {
+            stHash_destruct(fastas_map);
+        }
+        if (hal_species) {
+            stSet_destruct(hal_species);
+        }
+        st_logInfo("taffy norm is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+        return 0;
+    }
     while((alignment = get_next_block_and_remove_gap_columns(reader)) != NULL) {
         // First resort the rows to be alphabetical and then realign with any previous block. This ensures
         // we will not have any mergeable rows unlinked. Note:

--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -419,6 +419,109 @@ int64_t alignment_remove_all_gap_columns(Alignment *alignment) {
     return columns_to_remove;
 }
 
+stList *alignment_split_at_reference_gaps(Alignment *alignment) {
+    if(alignment->row == NULL || alignment->column_number == 0) {
+        return NULL;
+    }
+    int64_t column_number = alignment->column_number;
+    char *reference_bases = alignment->row->bases;
+    bool has_reference_gap = 0;
+    for(int64_t i=0; i<column_number; i++) {
+        if(reference_bases[i] == '-') {
+            has_reference_gap = 1;
+            break;
+        }
+    }
+    if(!has_reference_gap) {
+        return NULL; // Nothing to split, the caller can use the alignment as it stands
+    }
+
+    // Find the column ranges in which the reference has bases; each becomes a block
+    int64_t segment_number = 0;
+    for(int64_t i=0; i<column_number; ) {
+        while(i < column_number && reference_bases[i] == '-') { i++; }
+        if(i >= column_number) { break; }
+        segment_number++;
+        while(i < column_number && reference_bases[i] != '-') { i++; }
+    }
+    int64_t *segment_start = st_malloc(sizeof(int64_t) * (segment_number > 0 ? segment_number : 1));
+    int64_t *segment_end = st_malloc(sizeof(int64_t) * (segment_number > 0 ? segment_number : 1));
+    int64_t k = 0;
+    for(int64_t i=0; i<column_number; ) {
+        while(i < column_number && reference_bases[i] == '-') { i++; }
+        if(i >= column_number) { break; }
+        segment_start[k] = i;
+        while(i < column_number && reference_bases[i] != '-') { i++; }
+        segment_end[k++] = i;
+    }
+    assert(k == segment_number);
+
+    // Per row bookkeeping as we walk the columns left to right
+    int64_t row_number = alignment->row_number;
+    Alignment_Row **input_rows = st_malloc(sizeof(Alignment_Row *) * row_number);
+    int64_t row_index = 0;
+    for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        input_rows[row_index++] = row;
+    }
+    assert(row_index == row_number);
+    int64_t *consumed = st_calloc(row_number, sizeof(int64_t)); // bases of the row already passed over
+    int64_t *scanned_to = st_calloc(row_number, sizeof(int64_t)); // column the row has been scanned up to
+
+    stList *segments = stList_construct();
+    for(k=0; k<segment_number; k++) {
+        int64_t start = segment_start[k], end = segment_end[k];
+        Alignment *segment = st_calloc(1, sizeof(Alignment));
+        segment->column_number = end - start;
+        segment->column_tags = st_calloc(end - start, sizeof(Tag *));
+        for(int64_t i=start; i<end; i++) { // Take the tags of the columns we keep, leaving the
+            // removed columns' tags with the input alignment for it to clean up
+            segment->column_tags[i - start] = alignment->column_tags[i];
+            alignment->column_tags[i] = NULL;
+        }
+        Alignment_Row **p_row = &(segment->row);
+        for(int64_t r=0; r<row_number; r++) {
+            Alignment_Row *row = input_rows[r];
+            for(int64_t i=scanned_to[r]; i<start; i++) { // The bases in the columns being removed are
+                // not in any block, but the row still passes over them
+                if(row->bases[i] != '-') {
+                    consumed[r]++;
+                }
+            }
+            int64_t segment_length = 0;
+            for(int64_t i=start; i<end; i++) {
+                if(row->bases[i] != '-') {
+                    segment_length++;
+                }
+            }
+            scanned_to[r] = end;
+            if(segment_length == 0) { // The row has no bases here, so it is not in this block
+                continue;
+            }
+            Alignment_Row *new_row = st_calloc(1, sizeof(Alignment_Row));
+            new_row->sequence_name = stString_copy(row->sequence_name);
+            new_row->strand = row->strand;
+            new_row->sequence_length = row->sequence_length;
+            new_row->start = row->start + consumed[r];
+            new_row->length = segment_length;
+            new_row->bases = stString_getSubString(row->bases, start, end - start);
+            consumed[r] += segment_length;
+            *p_row = new_row;
+            p_row = &(new_row->n_row);
+            segment->row_number++;
+        }
+        assert(segment->row_number > 0); // The reference always has bases across a segment
+        stList_append(segments, segment);
+    }
+
+    free(consumed);
+    free(scanned_to);
+    free(input_rows);
+    free(segment_start);
+    free(segment_end);
+
+    return segments;
+}
+
 void alignment_get_column_in_buffer(Alignment *alignment, int64_t column_index, char *buffer) {
     assert(column_index >= 0);
     assert(column_index < alignment->column_number);

--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -193,15 +193,12 @@ void alignment_link_adjacent(Alignment *left_alignment, Alignment *right_alignme
                              // unless we disallow substitutions, in which case use an arbitrarily large mismatch cost
     int64_t aligned_rows[stList_length(left_rows)];
     WFA_get_alignment(wfa, aligned_rows);
-    // Remove any previous links
+    // Remove any previous links. Note we leave the left rows' left_gap_sequence alone: it describes
+    // the gap to the block before the left one, which this call does not touch. It is the right rows'
+    // gap sequences that this can invalidate, and those are checked below once the new links are in.
     Alignment_Row *row = left_alignment->row;
     while(row != NULL) {
         row->r_row = NULL;
-        // Clean up any gap sequences because once unlinked we can not guarantee continuity
-        if(row->left_gap_sequence != NULL) {
-            free(row->left_gap_sequence);
-            row->left_gap_sequence = NULL;
-        }
         row = row->n_row;
     }
     row = right_alignment->row;

--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -221,6 +221,25 @@ void alignment_link_adjacent(Alignment *left_alignment, Alignment *right_alignme
             }
         }
     }
+    // A row's left_gap_sequence holds the unaligned bases between it and its left row, so it is only
+    // meaningful for the link that was in place when it was created. Re-linking can pair a row with
+    // a different left row, or with one a different distance away, which leaves the sequence
+    // describing a gap that no longer exists. Drop any that no longer fit the gap they now span, so
+    // that they get regenerated instead of splicing the wrong number of bases into a merged row.
+    row = right_alignment->row;
+    while(row != NULL) {
+        if(row->left_gap_sequence != NULL) {
+            int64_t gap_length = -1; // No predecessor means there is no gap for it to describe
+            if(row->l_row != NULL && alignment_row_is_predecessor(row->l_row, row)) {
+                gap_length = row->start - (row->l_row->start + row->l_row->length);
+            }
+            if((int64_t)strlen(row->left_gap_sequence) != gap_length) {
+                free(row->left_gap_sequence);
+                row->left_gap_sequence = NULL;
+            }
+        }
+        row = row->n_row;
+    }
     // clean up
     stList_destruct(left_rows);
     stList_destruct(right_rows);

--- a/taffy/impl/merge_adjacent_alignments.c
+++ b/taffy/impl/merge_adjacent_alignments.c
@@ -515,6 +515,8 @@ Alignment *alignment_merge_adjacent(Alignment *left_alignment, Alignment *right_
         }
         for(int64_t i=0; i<right_alignment->column_number; i++) { // Add the right alignment's column's tags
             combined_column_tags[j++] = right_alignment->column_tags[i];
+            right_alignment->column_tags[i] = NULL; // The merged alignment owns them now, so the
+            // alignment_destruct below must not free them out from under it
         }
         free(left_alignment->column_tags); // Cleanup, but not the tag strings which we copied
         left_alignment->column_tags = combined_column_tags;

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -135,6 +135,22 @@ void alignment_set_rows(Alignment *alignment, stList *rows);
 int64_t alignment_remove_all_gap_columns(Alignment *alignment);
 
 /*
+ * Split the alignment at every run of columns in which the first (reference) row has a gap, removing
+ * those columns, so that no returned block has a reference gap. Returns the resulting blocks as a
+ * list of newly allocated alignments in left to right order; the caller still owns the alignment
+ * passed in and must destruct it.
+ *
+ * Returns NULL if the reference row has no gaps, meaning the alignment can be used as it is. Returns
+ * an empty list if the reference row is entirely gaps, as then no part of the alignment is anchored
+ * to the reference and the block goes away altogether.
+ *
+ * Each row's coordinates are recomputed from the bases it has in each block, and a row with no bases
+ * in a block is left out of it. The bases in the removed columns are not aligned to the reference and
+ * are dropped.
+ */
+stList *alignment_split_at_reference_gaps(Alignment *alignment);
+
+/*
  * Read a column of the alignment into the buffer. The buffer must be initialized and be at least
  * of length alignment->row_number.
  */

--- a/tests/column_tag_merge_test.taf
+++ b/tests/column_tag_merge_test.taf
@@ -1,0 +1,6 @@
+#taf version:1
+AA ; i 0 s1.c1 0 + 100 i 1 s2.c1 0 + 100 @ c:0
+-- @ c:allgap
+CC @ c:1
+GG ; @ c:2
+TT @ c:3

--- a/tests/column_tag_merge_test_truth.taf
+++ b/tests/column_tag_merge_test_truth.taf
@@ -1,0 +1,5 @@
+#taf version:1
+AA ; i 0 s1.c1 0 + 100 i 1 s2.c1 0 + 100 @ c:0
+CC @ c:1
+GG @ c:2
+TT @ c:3

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -463,6 +463,34 @@ static void test_gap_columns_after_filtering_a_species(CuTest *testCase) {
     st_system("rm -f %s %s", filtered_file, normalized_file);
 }
 
+/*
+ * taffy add-gap-bases records the unaligned sequence between two blocks as a TAF "G" record, whose
+ * length is tied to the gap between a row and the row it continues from. taffy norm re-links rows,
+ * which can pair a row with a different, or a differently distant, predecessor, so a gap sequence
+ * that no longer fits its gap must not be spliced into a merged row: doing so puts more bases in the
+ * row than its length field accounts for. This is the pipeline cactus uses, via the HAL backend.
+ */
+static void test_norm_with_gap_sequences(CuTest *testCase) {
+    char *gap_file = "./tests/evolverMammals.gapseq.taf";
+    char *output_file = "./tests/evolverMammals.gapseq.norm.maf";
+    int i = st_system("./bin/taffy view -i ./tests/evolverMammals.maf | "
+                      "./bin/taffy add-gap-bases ./tests/seqs/* > %s", gap_file);
+    CuAssertIntEquals(testCase, 0, i);
+    int j = st_system("./bin/taffy norm -i %s -k -o %s", gap_file, output_file);
+    CuAssertIntEquals(testCase, 0, j);
+    // count_all_gap_columns checks each row's length field against its non-gap base count, which is
+    // the invariant a stale gap sequence breaks
+    count_all_gap_columns(testCase, output_file);
+
+    // And again with the sequences available, where the gap sequences that no longer fit should be
+    // refilled with real bases rather than left as Ns
+    int k = st_system("./bin/taffy norm -i %s -k -b ./tests/seqs/* -o %s", gap_file, output_file);
+    CuAssertIntEquals(testCase, 0, k);
+    count_all_gap_columns(testCase, output_file);
+
+    st_system("rm -f %s %s", gap_file, output_file);
+}
+
 CuSuite* normalize_test_suite(void) {
     CuSuite* suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_remove_all_gap_columns);
@@ -470,6 +498,7 @@ CuSuite* normalize_test_suite(void) {
     SUITE_ADD_TEST(suite, test_all_gap_block_keeps_gap_sequence);
     SUITE_ADD_TEST(suite, test_gap_column_filter);
     SUITE_ADD_TEST(suite, test_gap_columns_after_filtering_a_species);
+    SUITE_ADD_TEST(suite, test_norm_with_gap_sequences);
     SUITE_ADD_TEST(suite, test_normalize);
     SUITE_ADD_TEST(suite, test_maf_norm);
     SUITE_ADD_TEST(suite, test_maf_norm_to_maf);

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -1,5 +1,6 @@
 #include "CuTest.h"
 #include "taf.h"
+#include "block_reader.h"
 #include "sonLib.h"
 #include "bioioC.h"
 
@@ -509,6 +510,231 @@ static void test_column_tags_through_merge(CuTest *testCase) {
     st_system("rm -f %s", output_file);
 }
 
+/*
+ * Count the columns of a maf whose reference (first) row has a gap, which is what unnormalizing has
+ * to leave none of. Also checks the invariants that splitting a block must not break: the bases of
+ * every row agree with its length field, and no column is entirely gaps.
+ */
+static int64_t count_reference_gap_columns(CuTest *testCase, char *maf_file) {
+    FILE *file = fopen(maf_file, "r");
+    CuAssertTrue(testCase, file != NULL);
+    LI *li = LI_construct(file);
+    Tag *header = maf_read_header(li);
+    tag_destruct(header);
+    int64_t reference_gap_columns = 0;
+    Alignment *alignment;
+    while((alignment = maf_read_block(li)) != NULL) {
+        CuAssertTrue(testCase, alignment->column_number > 0);
+        CuAssertTrue(testCase, alignment->row != NULL);
+        for(int64_t i=0; i<alignment->column_number; i++) {
+            if(alignment->row->bases[i] == '-') {
+                reference_gap_columns++;
+            }
+            bool all_gaps = 1;
+            for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+                if(row->bases[i] != '-') {
+                    all_gaps = 0;
+                    break;
+                }
+            }
+            CuAssertTrue(testCase, !all_gaps);
+        }
+        for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+            int64_t bases = 0;
+            for(int64_t i=0; i<alignment->column_number; i++) {
+                if(row->bases[i] != '-') {
+                    bases++;
+                }
+            }
+            CuAssertIntEquals(testCase, row->length, bases);
+            CuAssertTrue(testCase, bases > 0); // A row with no bases has no business being in a block
+        }
+        alignment_destruct(alignment, 1);
+    }
+    LI_destruct(li);
+    fclose(file);
+    return reference_gap_columns;
+}
+
+/*
+ * Write out a canonical description of every column of a maf that the reference has a base in: the
+ * sequence, strand, coordinate and base of each row aligned there, sorted so the description does
+ * not depend on the order the rows happen to be in. Two mafs describing the same alignment give the
+ * same file, whatever their block boundaries or row order, which is how the round trip below can
+ * compare an alignment against itself after it has been merged and split apart again.
+ */
+static void write_column_signatures(CuTest *testCase, char *maf_file, char *signature_file) {
+    FILE *in = fopen(maf_file, "r");
+    CuAssertTrue(testCase, in != NULL);
+    FILE *out = fopen(signature_file, "w");
+    CuAssertTrue(testCase, out != NULL);
+    LI *li = LI_construct(in);
+    Tag *header = maf_read_header(li);
+    tag_destruct(header);
+    Alignment *alignment;
+    while((alignment = maf_read_block(li)) != NULL) {
+        int64_t *coordinate = st_calloc(alignment->row_number, sizeof(int64_t));
+        int64_t i = 0;
+        for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+            coordinate[i++] = row->start;
+        }
+        for(int64_t c=0; c<alignment->column_number; c++) {
+            stList *entries = stList_construct3(0, free);
+            i = 0;
+            for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row, i++) {
+                if(row->bases[c] != '-') {
+                    stList_append(entries, stString_print("%s:%s:%" PRIi64 ":%c", row->sequence_name,
+                                                          row->strand ? "+" : "-", coordinate[i],
+                                                          row->bases[c]));
+                    coordinate[i]++;
+                }
+            }
+            if(alignment->row->bases[c] != '-') { // Only the columns anchored to the reference, as
+                // the others are exactly what unnormalizing removes
+                stList_sort(entries, (int (*)(const void *, const void *))strcmp);
+                for(int64_t j=0; j<stList_length(entries); j++) {
+                    fprintf(out, "%s%s", j == 0 ? "" : "|", (char *)stList_get(entries, j));
+                }
+                fprintf(out, "\n");
+            }
+            stList_destruct(entries);
+        }
+        free(coordinate);
+        alignment_destruct(alignment, 1);
+    }
+    LI_destruct(li);
+    fclose(in);
+    fclose(out);
+}
+
+// Unnormalizing a small maf: the two reference gap columns go, the block splits in two, each row's
+// coordinates follow the bases it actually has, and in taf output the bases removed from s2 come
+// back as the unaligned sequence before the second block.
+static void test_unnormalize(CuTest *testCase) {
+    char *input_file = "./tests/unnormalize_test.maf";
+    char *maf_out = "./tests/unnormalize_out.maf";
+    char *taf_out = "./tests/unnormalize_out.taf";
+    int i = st_system("./bin/taffy norm -i %s -u -k -o %s", input_file, maf_out);
+    CuAssertIntEquals(testCase, 0, i);
+    CuAssertIntEquals(testCase, 0, st_system("diff %s ./tests/unnormalize_test_truth.maf", maf_out));
+    int j = st_system("./bin/taffy norm -i %s -u -o %s", input_file, taf_out);
+    CuAssertIntEquals(testCase, 0, j);
+    CuAssertIntEquals(testCase, 0, st_system("diff %s ./tests/unnormalize_test_truth.taf", taf_out));
+    CuAssertIntEquals(testCase, 0, count_reference_gap_columns(testCase, maf_out));
+    st_system("rm -f %s %s", maf_out, taf_out);
+}
+
+// -u splits blocks rather than merging them, so combining it with the options that add gap sequence
+// or drop rows to enable a merge has to be refused rather than quietly ignored.
+static void test_unnormalize_rejects_merge_options(CuTest *testCase) {
+    CuAssertTrue(testCase, st_system("./bin/taffy norm -i ./tests/unnormalize_test.maf -u -d "
+                                     "-o /dev/null 2>/dev/null") != 0);
+    CuAssertTrue(testCase, st_system("./bin/taffy norm -i ./tests/unnormalize_test.maf -u "
+                                     "-b ./tests/seqs/* -o /dev/null 2>/dev/null") != 0);
+}
+
+/*
+ * The round trip. taffy norm merges the blocks of the evolver mammals alignment, which introduces
+ * reference gap columns where it splices in the sequence between the blocks it joined; -u splits it
+ * back apart at exactly those columns. The alignment that comes out has to describe the same columns
+ * as the one that went in.
+ *
+ * The block boundaries are not recovered: where two adjacent blocks had no gap at all in any row the
+ * merge spliced nothing in, so there is no reference gap left to split on. Those boundaries carry no
+ * alignment information, which is why this compares columns rather than files.
+ */
+static void test_unnormalize_round_trip(CuTest *testCase) {
+    char *original_taf = "./tests/rt.orig.taf";
+    char *normalized = "./tests/rt.norm.taf";
+    char *unnormalized = "./tests/rt.un.taf";
+    char *original_maf = "./tests/rt.orig.maf";
+    char *unnormalized_maf = "./tests/rt.un.maf";
+    char *original_signature = "./tests/rt.orig.sig";
+    char *unnormalized_signature = "./tests/rt.un.sig";
+
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i ./tests/evolverMammals.maf -o %s",
+                                             original_taf));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -o %s", original_taf, normalized));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -u -o %s", normalized, unnormalized));
+
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i %s -m -o %s", original_taf, original_maf));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i %s -m -o %s", unnormalized, unnormalized_maf));
+
+    // Nothing that came out has a reference gap, and the invariants of every block hold
+    CuAssertIntEquals(testCase, 0, count_reference_gap_columns(testCase, unnormalized_maf));
+    // The alignment that went in did not either, being straight out of hal2maf
+    CuAssertIntEquals(testCase, 0, count_reference_gap_columns(testCase, original_maf));
+
+    // And the columns are the same ones
+    write_column_signatures(testCase, original_maf, original_signature);
+    write_column_signatures(testCase, unnormalized_maf, unnormalized_signature);
+    CuAssertIntEquals(testCase, 0, st_system("diff %s %s", original_signature, unnormalized_signature));
+
+    // Splitting an already split alignment changes nothing
+    char *twice = "./tests/rt.un2.taf";
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -u -o %s", unnormalized, twice));
+    CuAssertIntEquals(testCase, 0, st_system("diff %s %s", unnormalized, twice));
+
+    st_system("rm -f %s %s %s %s %s %s %s %s", original_taf, normalized, unnormalized, original_maf,
+              unnormalized_maf, original_signature, unnormalized_signature, twice);
+}
+
+/*
+ * The aligned bases a taf accounts for, being the sum of its rows' lengths.
+ */
+static int64_t count_aligned_bases(CuTest *testCase, char *taf_file) {
+    FILE *file = fopen(taf_file, "r");
+    CuAssertTrue(testCase, file != NULL);
+    LI *li = LI_construct(file);
+    BlockReader *reader = block_reader_open(li);
+    CuAssertTrue(testCase, reader != NULL);
+    Tag *header = block_reader_take_header(reader);
+    tag_destruct(header);
+    int64_t aligned = 0;
+    Alignment *alignment, *p_alignment = NULL;
+    while((alignment = block_reader_next(reader, p_alignment)) != NULL) {
+        for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+            aligned += row->length;
+        }
+        if(p_alignment != NULL) {
+            alignment_destruct(p_alignment, 1);
+        }
+        p_alignment = alignment;
+    }
+    if(p_alignment != NULL) {
+        alignment_destruct(p_alignment, 1);
+    }
+    block_reader_destruct(reader);
+    LI_destruct(li);
+    fclose(file);
+    return aligned;
+}
+
+/*
+ * Merging pulls the sequence between two blocks into the alignment as columns the reference has gaps
+ * in, so it adds aligned bases; -u takes those columns back out. The count has to come back to
+ * exactly what it was before the merge, which is what pins the split to the right columns and each
+ * row to the right coordinates.
+ */
+static void test_unnormalize_restores_aligned_bases(CuTest *testCase) {
+    char *original = "./tests/un.orig.taf";
+    char *merged = "./tests/un.norm.taf";
+    char *split = "./tests/un.split.taf";
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i ./tests/evolverMammals.maf -o %s",
+                                             original));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -o %s", original, merged));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -u -o %s", merged, split));
+
+    int64_t before = count_aligned_bases(testCase, original);
+    int64_t after_merge = count_aligned_bases(testCase, merged);
+    int64_t after_split = count_aligned_bases(testCase, split);
+
+    CuAssertTrue(testCase, after_merge > before); // The merge made the reference gaps to split on
+    CuAssertIntEquals(testCase, before, after_split); // And splitting takes them all back out
+
+    st_system("rm -f %s %s %s", original, merged, split);
+}
+
 CuSuite* normalize_test_suite(void) {
     CuSuite* suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_remove_all_gap_columns);
@@ -518,6 +744,10 @@ CuSuite* normalize_test_suite(void) {
     SUITE_ADD_TEST(suite, test_gap_columns_after_filtering_a_species);
     SUITE_ADD_TEST(suite, test_norm_with_gap_sequences);
     SUITE_ADD_TEST(suite, test_column_tags_through_merge);
+    SUITE_ADD_TEST(suite, test_unnormalize);
+    SUITE_ADD_TEST(suite, test_unnormalize_rejects_merge_options);
+    SUITE_ADD_TEST(suite, test_unnormalize_round_trip);
+    SUITE_ADD_TEST(suite, test_unnormalize_restores_aligned_bases);
     SUITE_ADD_TEST(suite, test_normalize);
     SUITE_ADD_TEST(suite, test_maf_norm);
     SUITE_ADD_TEST(suite, test_maf_norm_to_maf);

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -491,6 +491,24 @@ static void test_norm_with_gap_sequences(CuTest *testCase) {
     st_system("rm -f %s %s", gap_file, output_file);
 }
 
+/*
+ * Merging two blocks moves the right block's column tags into the merged block, so the right block
+ * must not then free them: reading them back when the merged block is written is a use after free,
+ * which crashed taffy norm on any taf carrying column tags on a mergeable block. The input also has
+ * an all-gap column with a tag on it, so this covers the tags being remapped by both the merge and
+ * the gap column removal at once.
+ */
+static void test_column_tags_through_merge(CuTest *testCase) {
+    char *input_file = "./tests/column_tag_merge_test.taf";
+    char *output_file = "./tests/column_tag_merge_out.taf";
+    int i = st_system("./bin/taffy norm -i %s -o %s", input_file, output_file);
+    CuAssertIntEquals(testCase, 0, i); // must not crash
+    char *truth_file = "./tests/column_tag_merge_test_truth.taf";
+    int diff_ret = st_system("diff %s %s", output_file, truth_file);
+    CuAssertIntEquals(testCase, 0, diff_ret);
+    st_system("rm -f %s", output_file);
+}
+
 CuSuite* normalize_test_suite(void) {
     CuSuite* suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_remove_all_gap_columns);
@@ -499,6 +517,7 @@ CuSuite* normalize_test_suite(void) {
     SUITE_ADD_TEST(suite, test_gap_column_filter);
     SUITE_ADD_TEST(suite, test_gap_columns_after_filtering_a_species);
     SUITE_ADD_TEST(suite, test_norm_with_gap_sequences);
+    SUITE_ADD_TEST(suite, test_column_tags_through_merge);
     SUITE_ADD_TEST(suite, test_normalize);
     SUITE_ADD_TEST(suite, test_maf_norm);
     SUITE_ADD_TEST(suite, test_maf_norm_to_maf);

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -735,6 +735,107 @@ static void test_unnormalize_restores_aligned_bases(CuTest *testCase) {
     st_system("rm -f %s %s %s", original, merged, split);
 }
 
+/*
+ * The blocks a taf has and the unaligned bases it holds in gap sequences between them.
+ */
+static void count_taf_blocks_and_gap_bases(CuTest *testCase, char *taf_file, int64_t *blocks,
+                                           int64_t *gap_bases) {
+    FILE *file = fopen(taf_file, "r");
+    CuAssertTrue(testCase, file != NULL);
+    LI *li = LI_construct(file);
+    BlockReader *reader = block_reader_open(li);
+    CuAssertTrue(testCase, reader != NULL);
+    Tag *header = block_reader_take_header(reader);
+    tag_destruct(header);
+    *blocks = 0;
+    *gap_bases = 0;
+    Alignment *alignment, *p_alignment = NULL;
+    while((alignment = block_reader_next(reader, p_alignment)) != NULL) {
+        (*blocks)++;
+        for(Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+            if(row->left_gap_sequence != NULL) {
+                *gap_bases += strlen(row->left_gap_sequence);
+            }
+        }
+        if(p_alignment != NULL) {
+            alignment_destruct(p_alignment, 1);
+        }
+        p_alignment = alignment;
+    }
+    if(p_alignment != NULL) {
+        alignment_destruct(p_alignment, 1);
+    }
+    block_reader_destruct(reader);
+    LI_destruct(li);
+    fclose(file);
+}
+
+/*
+ * taffy sort relinks every block as it goes without merging anything, so a row can end up continuing
+ * from a different predecessor than the one its gap sequence was worked out against. Left holding a
+ * sequence that no longer spans its gap, write_coordinates aborts: sorting a taf that had been
+ * through add-gap-bases used to die partway through and leave a truncated file behind.
+ */
+static void test_sort_keeps_gap_sequences(CuTest *testCase) {
+    char *gap_file = "./tests/sort.gapseq.taf";
+    char *sorted_file = "./tests/sort.gapseq.sorted.taf";
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i ./tests/evolverMammals.maf -o %s.tmp",
+                                             gap_file));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy add-gap-bases -i %s.tmp ./tests/seqs/* -o %s",
+                                             gap_file, gap_file));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy sort -i %s -n ./tests/sort_file.txt -o %s",
+                                             gap_file, sorted_file));
+
+    int64_t blocks_before, gap_before, blocks_after, gap_after;
+    count_taf_blocks_and_gap_bases(testCase, gap_file, &blocks_before, &gap_before);
+    count_taf_blocks_and_gap_bases(testCase, sorted_file, &blocks_after, &gap_after);
+
+    CuAssertTrue(testCase, gap_before > 0); // The input has to have gap sequences to lose
+    CuAssertIntEquals(testCase, blocks_before, blocks_after); // Nothing truncated by an abort
+    // And essentially nothing downgraded to a bare gap length. Not quite all of them survive: where
+    // a sequence occurs more than once in a block, relinking can legitimately pair a row with a
+    // different, further away copy than the one its gap sequence was worked out against, and a
+    // sequence that no longer spans the gap has to be dropped. That accounts for 61 bases here.
+    CuAssertTrue(testCase, gap_after * 100 > gap_before * 99);
+    st_system("rm -f %s %s.tmp %s", gap_file, gap_file, sorted_file);
+}
+
+// Splitting a block moves the column tags of the columns it keeps into the new blocks, and the tags
+// of the reference-gap columns it removes go with them. Neither may be freed twice or leaked.
+static void test_unnormalize_column_tags(CuTest *testCase) {
+    char *input_file = "./tests/unnormalize_tags_test.taf";
+    char *output_file = "./tests/unnormalize_tags_out.taf";
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -u -o %s", input_file, output_file));
+    CuAssertIntEquals(testCase, 0, st_system("diff %s ./tests/unnormalize_tags_test_truth.taf",
+                                             output_file));
+    st_system("rm -f %s", output_file);
+}
+
+/*
+ * taffy norm links a block to the next one and then writes that same block, so clearing gap sequences
+ * on the left side of a link threw them away just before they were needed. Everything add-gap-bases
+ * had put in came out as a bare gap length instead. The merged blocks legitimately lose theirs, the
+ * sequence having become alignment columns, but the boundaries that remain have to keep them.
+ */
+static void test_norm_keeps_gap_sequences(CuTest *testCase) {
+    char *gap_file = "./tests/norm.gapseq.taf";
+    char *normed_file = "./tests/norm.gapseq.normed.taf";
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy view -i ./tests/evolverMammals.maf -o %s.tmp",
+                                             gap_file));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy add-gap-bases -i %s.tmp ./tests/seqs/* -o %s",
+                                             gap_file, gap_file));
+    CuAssertIntEquals(testCase, 0, st_system("./bin/taffy norm -i %s -o %s", gap_file, normed_file));
+
+    int64_t blocks_before, gap_before, blocks_after, gap_after;
+    count_taf_blocks_and_gap_bases(testCase, gap_file, &blocks_before, &gap_before);
+    count_taf_blocks_and_gap_bases(testCase, normed_file, &blocks_after, &gap_after);
+
+    CuAssertTrue(testCase, gap_before > 0); // The input has to have gap sequences to lose
+    CuAssertTrue(testCase, blocks_after < blocks_before); // And norm has to have merged blocks
+    CuAssertTrue(testCase, gap_after > 0); // The boundaries that survived keep their sequence
+    st_system("rm -f %s %s.tmp %s", gap_file, gap_file, normed_file);
+}
+
 CuSuite* normalize_test_suite(void) {
     CuSuite* suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_remove_all_gap_columns);
@@ -748,6 +849,9 @@ CuSuite* normalize_test_suite(void) {
     SUITE_ADD_TEST(suite, test_unnormalize_rejects_merge_options);
     SUITE_ADD_TEST(suite, test_unnormalize_round_trip);
     SUITE_ADD_TEST(suite, test_unnormalize_restores_aligned_bases);
+    SUITE_ADD_TEST(suite, test_unnormalize_column_tags);
+    SUITE_ADD_TEST(suite, test_sort_keeps_gap_sequences);
+    SUITE_ADD_TEST(suite, test_norm_keeps_gap_sequences);
     SUITE_ADD_TEST(suite, test_normalize);
     SUITE_ADD_TEST(suite, test_maf_norm);
     SUITE_ADD_TEST(suite, test_maf_norm_to_maf);

--- a/tests/unnormalize_tags_test.taf
+++ b/tests/unnormalize_tags_test.taf
@@ -1,0 +1,4 @@
+#taf version:1
+AA ; i 0 ref.c1 0 + 100 i 1 s2.c1 0 + 100 @ c:zero
+-T @ c:refgap
+CC @ c:one

--- a/tests/unnormalize_tags_test_truth.taf
+++ b/tests/unnormalize_tags_test_truth.taf
@@ -1,0 +1,3 @@
+#taf version:1
+AA ; i 0 ref.c1 0 + 100 i 1 s2.c1 0 + 100 @ c:zero
+CC ; g 1 1 @ c:one

--- a/tests/unnormalize_test.maf
+++ b/tests/unnormalize_test.maf
@@ -1,0 +1,6 @@
+##maf version=1
+
+a
+s	ref.c1	0	4	+	100	AC--GT
+s	s2.c1	0	6	+	100	ACTTGT
+s	s3.c1	0	3	+	100	-C--GT

--- a/tests/unnormalize_test_truth.maf
+++ b/tests/unnormalize_test_truth.maf
@@ -1,0 +1,12 @@
+##maf version=1
+
+a
+s	ref.c1	0	2	+	100	AC
+s	s2.c1	0	2	+	100	AC
+s	s3.c1	0	1	+	100	-C
+
+a
+s	ref.c1	2	2	+	100	GT
+s	s2.c1	4	2	+	100	GT
+s	s3.c1	1	2	+	100	GT
+

--- a/tests/unnormalize_test_truth.taf
+++ b/tests/unnormalize_test_truth.taf
@@ -1,0 +1,5 @@
+#taf version:1
+AA- ; i 0 ref.c1 0 + 100 i 1 s2.c1 0 + 100 i 2 s3.c1 0 + 100
+CCC
+GGG ; g 1 2
+TTT


### PR DESCRIPTION
Add `taffy norm -u` to break apart blocks at reference gaps (effecitively undoing normalization). 